### PR TITLE
Use realtime snapshot for notes

### DIFF
--- a/app/apis/firestore/note.ts
+++ b/app/apis/firestore/note.ts
@@ -1,13 +1,9 @@
 import {
   addDoc,
   collection,
-  query,
-  getDocs,
   doc,
   updateDoc,
-  where,
   deleteDoc,
-  FieldPath,
 } from 'firebase/firestore'
 
 import { auth, firestore } from '~/lib/configs/firebase'
@@ -19,40 +15,6 @@ import {
   TUpdateNoteRequest,
 } from '~/lib/types/note'
 import { waitForAuth } from '~/lib/utils/wait-for-auth'
-
-export const fetchNotes = async () => {
-  if (!firestore) {
-    throw new Error('Firebase DB is not initialized')
-  }
-  if (!auth) {
-    throw new Error('Firebase Auth is not initialized')
-  }
-
-  const user = auth.currentUser ?? (await waitForAuth())
-  if (!user) {
-    return []
-  }
-
-  const notesQuery = query(
-    collection(firestore, 'notes'),
-    where(
-      new FieldPath('permissions', 'read'),
-      'array-contains',
-      user.uid,
-    ),
-  )
-  const snap = await getDocs(notesQuery)
-
-  // Map over the snapshot documents, including both data and ID
-  return snap.docs.map((document) => {
-    const data = document.data()
-    return {
-      ...data,
-      id: document.id, // Get document ID
-      isPinned: data.pinnedBy?.includes(user.uid),
-    } as TNoteResponse
-  })
-}
 
 export const createNote = async (data: TCreateNoteRequest) => {
   if (!firestore) {

--- a/app/lib/hooks/use-create-note.ts
+++ b/app/lib/hooks/use-create-note.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRevalidator } from 'react-router'
 
 import { createNote } from '~/apis/firestore/note'
 import { TCreateNoteRequest } from '~/lib/types/note'
@@ -7,7 +6,6 @@ import { TCreateNoteRequest } from '~/lib/types/note'
 import { toast } from './use-toast'
 
 export const useCreateNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
 
@@ -16,7 +14,6 @@ export const useCreateNote = () => {
     setIsError(false)
     try {
       await createNote(data)
-      revalidate()
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/lib/hooks/use-delete-note.tsx
+++ b/app/lib/hooks/use-delete-note.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useRevalidator } from 'react-router'
 
 import { deleteNote } from '~/apis/firestore/note'
 import { ToastAction } from '~/components/ui/toast'
@@ -10,7 +9,6 @@ import { useCreateNote } from './use-create-note'
 import { toast } from './use-toast'
 
 export const useDeleteNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const { mutate: mutateCreateNote } = useCreateNote()
   const { t } = useTranslation()
@@ -20,7 +18,6 @@ export const useDeleteNote = () => {
     try {
       const { isPinned: _isPinned, id: _id, ...data } = note
       await deleteNote(note)
-      revalidate()
       toast({
         description: t('notes.toast.deleted'),
         action: (

--- a/app/lib/hooks/use-get-notes.ts
+++ b/app/lib/hooks/use-get-notes.ts
@@ -1,8 +1,58 @@
-import { useLoaderData } from 'react-router'
+import {
+  collection,
+  FieldPath,
+  onSnapshot,
+  query,
+  where,
+} from 'firebase/firestore'
+import { useEffect, useState } from 'react'
 
+import { auth, firestore } from '~/lib/configs/firebase'
 import { TNoteResponse } from '~/lib/types/note'
+import { waitForAuth } from '~/lib/utils/wait-for-auth'
 
 export const useGetNotes = () => {
-  const data = useLoaderData() as { notes: TNoteResponse[] }
-  return { data: data.notes }
+  const [data, setData] = useState<TNoteResponse[]>()
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (!firestore) return
+    const db = firestore
+    let unsubscribe: () => void
+
+    const listen = async () => {
+      const user = auth?.currentUser ?? (await waitForAuth())
+      if (!user) {
+        setData([])
+        setIsLoading(false)
+        return
+      }
+
+      const notesQuery = query(
+        collection(db, 'notes'),
+        where(new FieldPath('permissions', 'read'), 'array-contains', user.uid),
+      )
+
+      unsubscribe = onSnapshot(notesQuery, (snap) => {
+        const result = snap.docs.map((document) => {
+          const noteData = document.data()
+          return {
+            ...noteData,
+            id: document.id,
+            isPinned: noteData.pinnedBy?.includes(user.uid),
+          } as TNoteResponse
+        })
+        setData(result)
+        setIsLoading(false)
+      })
+    }
+
+    void listen()
+
+    return () => {
+      if (unsubscribe) unsubscribe()
+    }
+  }, [])
+
+  return { data, isLoading }
 }

--- a/app/lib/hooks/use-pin-note.ts
+++ b/app/lib/hooks/use-pin-note.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRevalidator } from 'react-router'
 
 import { pinNote } from '~/apis/firestore/note'
 import { TPinNoteRequest } from '~/lib/types/note'
@@ -7,7 +6,6 @@ import { TPinNoteRequest } from '~/lib/types/note'
 import { toast } from './use-toast'
 
 export const usePinNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
 
@@ -16,7 +14,6 @@ export const usePinNote = () => {
     setIsError(false)
     try {
       await pinNote(data)
-      revalidate()
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/lib/hooks/use-share-note.ts
+++ b/app/lib/hooks/use-share-note.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRevalidator } from 'react-router'
 
 import { setNotePermission } from '~/apis/firestore/note'
 import { TNotePermissionRequest } from '~/lib/types/note'
@@ -7,7 +6,6 @@ import { TNotePermissionRequest } from '~/lib/types/note'
 import { toast } from './use-toast'
 
 export const useShareNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
 
@@ -16,7 +14,6 @@ export const useShareNote = () => {
     setIsError(false)
     try {
       await setNotePermission(data)
-      revalidate()
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/lib/hooks/use-unlink-note.ts
+++ b/app/lib/hooks/use-unlink-note.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRevalidator } from 'react-router'
 
 import { unlinkNote } from '~/apis/firestore/note'
 import { TNoteResponse } from '~/lib/types/note'
@@ -7,7 +6,6 @@ import { TNoteResponse } from '~/lib/types/note'
 import { toast } from './use-toast'
 
 export const useUnlinkNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
 
@@ -16,7 +14,6 @@ export const useUnlinkNote = () => {
     setIsError(false)
     try {
       await unlinkNote(data)
-      revalidate()
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/lib/hooks/use-update-note.ts
+++ b/app/lib/hooks/use-update-note.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useRevalidator } from 'react-router'
 
 import { updateNote } from '~/apis/firestore/note'
 import { TUpdateNoteRequest } from '~/lib/types/note'
@@ -7,7 +6,6 @@ import { TUpdateNoteRequest } from '~/lib/types/note'
 import { toast } from './use-toast'
 
 export const useUpdateNote = () => {
-  const { revalidate } = useRevalidator()
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
 
@@ -16,7 +14,6 @@ export const useUpdateNote = () => {
     setIsError(false)
     try {
       await updateNote(data)
-      revalidate()
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/routes/_layout.dashboard.notes.tsx
+++ b/app/routes/_layout.dashboard.notes.tsx
@@ -1,12 +1,4 @@
-import { type ClientLoaderFunctionArgs } from 'react-router'
-
-import { fetchNotes } from '~/apis/firestore/note'
 import { NotesPage } from '~/components/pages/notes'
-
-export const clientLoader = async (_: ClientLoaderFunctionArgs) => {
-  const notes = await fetchNotes()
-  return { notes }
-}
 
 const Notes = () => <NotesPage />
 


### PR DESCRIPTION
## Summary
- remove static fetching of notes and use Firestore `onSnapshot`
- stop revalidating router data after note mutations
- clean up unused loader and API code

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:unused`


------
https://chatgpt.com/codex/tasks/task_e_686f95714c7c832894e788705ba3b272