### PR TITLE
Add note create success toast and navigation

### DIFF
--- a/app/components/pages/notes/form.tsx
+++ b/app/components/pages/notes/form.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { forwardRef, useImperativeHandle } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router'
 
 import { Action } from '~/components/base/action'
 import { Textarea } from '~/components/base/textarea'
@@ -49,6 +50,7 @@ export const Form = forwardRef((properties: TFormProperties, reference) => {
     ].filter((uid) => uid !== auth?.currentUser?.uid),
   ).size
   const { mutate: mutateCreateNote } = useCreateNote()
+  const navigate = useNavigate()
   const { mutate: mutateUpdateNote } = useUpdateNote()
   const formMethods = useForm<TNoteForm>({
     resolver: zodResolver(noteSchema),
@@ -73,7 +75,10 @@ export const Form = forwardRef((properties: TFormProperties, reference) => {
       mutateUpdateNote({ id: selectedNote.id, ...data })
       return
     }
-    mutateCreateNote(data)
+    const reference = await mutateCreateNote(data)
+    if (reference) {
+      navigate(`/notes/${reference.id}`)
+    }
   })
 
   useDebounce({

--- a/app/lib/hooks/use-create-note.ts
+++ b/app/lib/hooks/use-create-note.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { createNote } from '~/apis/firestore/note'
 import { TCreateNoteRequest } from '~/lib/types/note'
@@ -8,12 +9,17 @@ import { toast } from './use-toast'
 export const useCreateNote = () => {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
+  const { t } = useTranslation()
 
   const mutate = async (data: TCreateNoteRequest) => {
     setIsPending(true)
     setIsError(false)
     try {
-      await createNote(data)
+      const reference = await createNote(data)
+      toast({
+        description: t('notes.toast.created'),
+      })
+      return reference
     } catch (error: unknown) {
       setIsError(true)
       const message = String(error)

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -113,7 +113,8 @@
       }
     },
     "toast": {
-      "deleted": "Note deleted successfully"
+      "deleted": "Note deleted successfully",
+      "created": "Note created successfully"
     }
   },
   "moneyLog": {

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -113,7 +113,8 @@
       }
     },
     "toast": {
-      "deleted": "Catatan berhasil dihapus"
+      "deleted": "Catatan berhasil dihapus",
+      "created": "Catatan berhasil dibuat"
     }
   },
   "moneyLog": {


### PR DESCRIPTION
## Summary
- show success toast when creating a note
- switch to update state by navigating to new note
- update locales with create toast messages

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec knip`


------
https://chatgpt.com/codex/tasks/task_e_6870e06f28508328b5d67678ffcd4356