### PR TITLE
Implement clientLoader for user data reuse

### DIFF
--- a/app/lib/hooks/use-get-user.ts
+++ b/app/lib/hooks/use-get-user.ts
@@ -1,26 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useRouteLoaderData } from 'react-router'
 
-import { fetchUserData } from '~/apis/firestore/user'
-import { auth } from '~/lib/configs/firebase'
 import { TUserResponse } from '~/lib/types/user'
+import { clientLoader as mainLoader } from '~/routes/_layout._main'
 
-// Custom hook to fetch current user data
+// Custom hook to access current user data from the layout loader
 export const useUserData = () => {
-  const [data, setData] = useState<TUserResponse | undefined>()
-  const [isLoading, setIsLoading] = useState(true)
+  const data = useRouteLoaderData<typeof mainLoader>('routes/_layout._main') as
+    | TUserResponse
+    | undefined
 
-  useEffect(() => {
-    const load = async () => {
-      if (!auth?.currentUser) {
-        setIsLoading(false)
-        return
-      }
-      const result = await fetchUserData()
-      setData(result)
-      setIsLoading(false)
-    }
-    load()
-  }, [])
-
-  return { data, isLoading }
+  return { data, isLoading: false }
 }

--- a/app/routes/_layout._main.tsx
+++ b/app/routes/_layout._main.tsx
@@ -1,6 +1,15 @@
 import { Outlet } from 'react-router'
 
+import { fetchUserData } from '~/apis/firestore/user'
 import { Navbar } from '~/components/layouts/navbar'
+
+export const clientLoader = async () => {
+  try {
+    return await fetchUserData()
+  } catch {
+    return null
+  }
+}
 
 const Dashboard = () => {
   return (


### PR DESCRIPTION
## Summary
- fetch user data via `clientLoader` in `_layout._main.tsx`
- expose loader data through `useUserData` hook

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`


------
https://chatgpt.com/codex/tasks/task_e_68730cad3dc08328b2b7ee7b3469ef1d