### PR TITLE
Implement LoadingScreen wrapper

### DIFF
--- a/app/components/base/loading-screen/index.tsx
+++ b/app/components/base/loading-screen/index.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from 'react'
+
+import { LoadingSpinner } from '~/components/base/loading-spinner'
+import { cn } from '~/lib/utils/shadcn'
+
+import { TProperties } from './type'
+
+export const LoadingScreen = (properties: PropsWithChildren<TProperties>) => {
+  const { isLoading, children, classname } = properties
+
+  if (isLoading) {
+    return <LoadingSpinner classname={cn('min-h-fit flex-1', classname)} />
+  }
+
+  return <>{children}</>
+}

--- a/app/components/base/loading-screen/type.ts
+++ b/app/components/base/loading-screen/type.ts
@@ -1,0 +1,7 @@
+import { HTMLAttributes, ReactNode } from 'react'
+
+export type TProperties = {
+  isLoading: boolean
+  classname?: HTMLAttributes<HTMLDivElement>['className']
+  children?: ReactNode
+}

--- a/app/components/pages/note-detail/content.tsx
+++ b/app/components/pages/note-detail/content.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useParams } from 'react-router'
 
-import { LoadingSpinner } from '~/components/base/loading-spinner'
+import { LoadingScreen } from '~/components/base/loading-screen'
 import { Modal } from '~/components/base/modal'
 import { Share } from '~/components/base/share'
 import { Form, useNote } from '~/components/pages/notes'
@@ -53,7 +53,7 @@ export const Content = () => {
     mutateShare(data)
   }
 
-  if (!notes) return <LoadingSpinner classname="min-h-fit flex-1" />
+  if (!notes) return <LoadingScreen isLoading classname="min-h-fit flex-1" />
 
   return (
     <main className="flex flex-1 flex-col gap-4 bg-muted/40 p-4 md:gap-8 md:p-8">

--- a/app/routes/_layout._main.tasks.tsx
+++ b/app/routes/_layout._main.tasks.tsx
@@ -1,7 +1,7 @@
-import { LoadingSpinner } from '~/components/base/loading-spinner'
+import { LoadingScreen } from '~/components/base/loading-screen'
 
 const Tasks = () => {
-  return <LoadingSpinner classname="min-h-fit flex-1" />
+  return <LoadingScreen isLoading classname="min-h-fit flex-1" />
 }
 
 export default Tasks


### PR DESCRIPTION
## Summary
- add `LoadingScreen` component to wrap `LoadingSpinner`
- use `LoadingScreen` in tasks and note detail pages

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip` *(fails: mise config not trusted)*

------
https://chatgpt.com/codex/tasks/task_e_68748b3e55308328a53132cc5d7487c7