### PR TITLE
feat: allow preview before saving appearance

### DIFF
--- a/app/apis/firestore/user.ts
+++ b/app/apis/firestore/user.ts
@@ -18,6 +18,7 @@ import {
 } from 'firebase/firestore'
 
 import { auth, firestore } from '~/lib/configs/firebase' // Assuming your Firestore is configured here
+import { Theme } from '~/lib/contexts/theme'
 import { TUpdateProfileRequest } from '~/lib/types/settings'
 import { TSignInRequest, TSignUpRequest, TUserResponse } from '~/lib/types/user'
 import { waitForAuth } from '~/lib/utils/wait-for-auth'
@@ -106,6 +107,23 @@ export const updateProfile = async (userData: TUpdateProfileRequest) => {
   })
 }
 
+export const updateAppearance = async (data: {
+  theme?: Theme
+  language?: string
+}) => {
+  if (!firestore) {
+    throw new Error('Firebase Firestore is not initialized.')
+  }
+  if (!auth?.currentUser) {
+    throw new Error('No user is currently signed in.')
+  }
+  const reference = doc(firestore, 'users', auth.currentUser.uid)
+  return await updateDoc(reference, {
+    ...data,
+    updatedAt: new Date(),
+  })
+}
+
 export const login = async (userData: TSignInRequest) => {
   const { email, password } = userData
   if (!auth || !firestore) {
@@ -160,7 +178,7 @@ export const loginWithGoogle = async () => {
 }
 
 export const register = async (userData: TSignUpRequest) => {
-  const { email, password, displayName } = userData
+  const { email, password, displayName, language, theme } = userData
   if (!auth || !firestore) {
     throw new Error('Firebase is not initialized.')
   }
@@ -185,6 +203,8 @@ export const register = async (userData: TSignUpRequest) => {
     await setDoc(doc(firestore, 'users', user.uid), {
       displayName: displayName,
       email: email,
+      language,
+      theme,
       createdAt: new Date(),
     })
   } else {

--- a/app/components/base/language-selector/index.tsx
+++ b/app/components/base/language-selector/index.tsx
@@ -17,22 +17,35 @@ import { languageOptions } from '~/localization/i18n'
 import { TParameters, TProperties } from './type'
 
 export const LanguageSelector = (properties: TProperties) => {
-  const { type = 'dropdown' } = properties
+  const { type = 'dropdown', onChange, value } = properties
   const { i18n } = useTranslation()
   const changeLanguage = (lng: string) => {
-    i18n.changeLanguage(lng)
+    if (value === undefined) {
+      i18n.changeLanguage(lng)
+    }
+    onChange?.(lng)
   }
 
   if (type === 'radio') {
-    return <Radio changeLanguage={changeLanguage} />
+    return (
+      <Radio
+        changeLanguage={changeLanguage}
+        value={value ?? i18n.language}
+      />
+    )
   }
 
-  return <Dropdown changeLanguage={changeLanguage} />
+  return (
+    <Dropdown
+      changeLanguage={changeLanguage}
+      value={value ?? i18n.language}
+    />
+  )
 }
 
 const Radio = (parameters: TParameters) => {
-  const { changeLanguage } = parameters
-  const { t, i18n } = useTranslation()
+  const { changeLanguage, value } = parameters
+  const { t } = useTranslation()
 
   return (
     <div className="space-y-1">
@@ -40,7 +53,7 @@ const Radio = (parameters: TParameters) => {
       <Slot>
         <RadioGroup
           onValueChange={changeLanguage}
-          value={i18n.language}
+          value={value}
           className="flex flex-col"
         >
           {languageOptions.map((option) => (
@@ -69,8 +82,8 @@ const Radio = (parameters: TParameters) => {
 }
 
 const Dropdown = (parameters: TParameters) => {
-  const { changeLanguage } = parameters
-  const { t, i18n } = useTranslation()
+  const { changeLanguage, value } = parameters
+  const { t } = useTranslation()
 
   return (
     <DropdownMenu>
@@ -87,7 +100,7 @@ const Dropdown = (parameters: TParameters) => {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuRadioGroup
-          value={i18n.language}
+          value={value}
           onValueChange={changeLanguage}
         >
           {languageOptions.map((option) => (

--- a/app/components/base/language-selector/type.ts
+++ b/app/components/base/language-selector/type.ts
@@ -1,7 +1,10 @@
 export type TProperties = {
   type?: 'dropdown' | 'radio'
+  value?: string
+  onChange?: (lng: string) => void
 }
 
 export type TParameters = {
+  value: string
   changeLanguage: (lng: string) => void
 }

--- a/app/components/base/mode-toggle/index.tsx
+++ b/app/components/base/mode-toggle/index.tsx
@@ -18,17 +18,21 @@ import { themeOptions } from './constant'
 import { TParameters, TProperties } from './type'
 
 export const ModeToggle = (properties: TProperties) => {
-  const { type = 'dropdown' } = properties
+  const { type = 'dropdown', onChange, value } = properties
   const { setTheme, theme } = useTheme()
+  const currentTheme = value ?? theme
 
   const handleSetTheme = (theme: Theme) => {
-    setTheme(theme)
+    if (value === undefined) {
+      setTheme(theme)
+    }
+    onChange?.(theme)
   }
 
   if (type === 'radio') {
     return (
       <Radio
-        value={theme}
+        value={currentTheme}
         handleSetTheme={handleSetTheme}
       />
     )
@@ -36,7 +40,7 @@ export const ModeToggle = (properties: TProperties) => {
 
   return (
     <Dropdown
-      value={theme}
+      value={currentTheme}
       handleSetTheme={handleSetTheme}
     />
   )

--- a/app/components/base/mode-toggle/type.ts
+++ b/app/components/base/mode-toggle/type.ts
@@ -2,6 +2,8 @@ import { Theme } from '~/lib/contexts/theme'
 
 export type TProperties = {
   type?: 'dropdown' | 'radio'
+  value?: Theme
+  onChange?: (value: Theme) => void
 }
 
 export type TParameters = {

--- a/app/components/pages/general-settings/appearance.tsx
+++ b/app/components/pages/general-settings/appearance.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
+import { Button } from '~/components/base/button'
 import { LanguageSelector } from '~/components/base/language-selector'
 import { ModeToggle } from '~/components/base/mode-toggle'
 import {
@@ -10,9 +12,54 @@ import {
   CardTitle,
 } from '~/components/ui/card'
 import { appName } from '~/lib/constants/metadata'
+import { Theme, useTheme } from '~/lib/contexts/theme'
+import { useUpdateAppearance } from '~/lib/hooks/use-update-appearance'
 
 export const Appearance = () => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const { theme, setTheme } = useTheme()
+  const { mutate, isPending } = useUpdateAppearance()
+
+  const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
+  const [selectedTheme, setSelectedTheme] = useState<Theme>(theme)
+
+  const initialLanguage = useRef(i18n.language)
+  const initialTheme = useRef(theme)
+  const isSaved = useRef(false)
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.remove('light', 'dark')
+    const value = selectedTheme
+    if (value === 'system') {
+      const systemTheme = globalThis.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light'
+      root.classList.add(systemTheme)
+    } else {
+      root.classList.add(value)
+    }
+  }, [selectedTheme])
+
+  useEffect(() => {
+    i18n.changeLanguage(selectedLanguage)
+  }, [selectedLanguage, i18n])
+
+  useEffect(() => {
+    return () => {
+      if (!isSaved.current) {
+        setTheme(initialTheme.current)
+        i18n.changeLanguage(initialLanguage.current)
+      }
+    }
+  }, [setTheme, i18n])
+
+  const handleSave = async () => {
+    await mutate({ theme: selectedTheme, language: selectedLanguage })
+    setTheme(selectedTheme)
+    isSaved.current = true
+  }
 
   return (
     <Card>
@@ -26,11 +73,29 @@ export const Appearance = () => {
           />
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="grid space-y-6">
-          <LanguageSelector type="radio" />
-          <ModeToggle type="radio" />
-        </div>
+      <CardContent className="space-y-6">
+        <LanguageSelector
+          type="radio"
+          value={selectedLanguage}
+          onChange={(lng) => setSelectedLanguage(lng)}
+        />
+        <ModeToggle
+          type="radio"
+          value={selectedTheme}
+          onChange={(value) => setSelectedTheme(value)}
+        />
+        <Button
+          className="w-fit"
+          isLoading={isPending}
+          disabled={
+            isPending ||
+            (selectedLanguage === initialLanguage.current &&
+              selectedTheme === initialTheme.current)
+          }
+          onClick={handleSave}
+        >
+          {t('form.save')}
+        </Button>
       </CardContent>
     </Card>
   )

--- a/app/components/pages/sign-up/index.tsx
+++ b/app/components/pages/sign-up/index.tsx
@@ -18,14 +18,16 @@ import {
   CardTitle,
   Card,
 } from '~/components/ui/card'
+import { useTheme } from '~/lib/contexts/theme'
 import { useRegister } from '~/lib/hooks/use-register'
 import { TSignUpRequest } from '~/lib/types/user'
 import { signUpSchema } from '~/lib/validations/user'
 
 export const SignUpPage = () => {
-  const { t } = useTranslation(['common', 'zod'])
+  const { t, i18n } = useTranslation(['common', 'zod'])
   const [disabled, setDisabled] = useState(false)
   const [passwordType, setPasswordType] = useState('password')
+  const { theme } = useTheme()
   const formMethods = useForm<TSignUpRequest>({
     resolver: zodResolver(signUpSchema(t)),
     defaultValues: {
@@ -38,7 +40,7 @@ export const SignUpPage = () => {
   const { handleSubmit } = formMethods
   const onSubmit = handleSubmit(async (data) => {
     setDisabled(true)
-    mutateRegister(data)
+    mutateRegister({ ...data, theme, language: i18n.language })
   })
   const togglePassword = () => {
     setPasswordType((previous) =>

--- a/app/lib/hooks/use-update-appearance.ts
+++ b/app/lib/hooks/use-update-appearance.ts
@@ -1,0 +1,48 @@
+import { FirebaseError } from 'firebase/app'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRevalidator } from 'react-router'
+
+import { updateAppearance } from '~/apis/firestore/user'
+import { authError } from '~/lib/constants/firebase'
+import { Theme } from '~/lib/contexts/theme'
+
+import { toast } from './use-toast'
+
+export const useUpdateAppearance = () => {
+  const { revalidate } = useRevalidator()
+  const { t } = useTranslation()
+  const [isPending, setIsPending] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const mutate = async (data: { theme?: Theme; language?: string }) => {
+    setIsPending(true)
+    setIsError(false)
+    setIsSuccess(false)
+    try {
+      await updateAppearance(data)
+      toast({
+        description: t('settings.appearance.toast.updated'),
+      })
+      setIsSuccess(true)
+      revalidate()
+    } catch (error: unknown) {
+      setIsError(true)
+      let message = String(error)
+      if (error instanceof FirebaseError) {
+        message =
+          authError.find((item) => item.code === error.code)?.message ||
+          error.message
+      }
+      toast({
+        variant: 'destructive',
+        description: message,
+      })
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return { mutate, isPending, isError, isSuccess }
+}

--- a/app/lib/types/user.ts
+++ b/app/lib/types/user.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod'
 
+import { Theme } from '~/lib/contexts/theme'
 import { TTime } from '~/lib/types/common'
 import { emailSchema, signInSchema, signUpSchema } from '~/lib/validations/user'
 
 export type TSignInRequest = z.infer<ReturnType<typeof signInSchema>>
 
-export type TSignUpRequest = z.infer<ReturnType<typeof signUpSchema>>
+export type TSignUpRequest = z.infer<ReturnType<typeof signUpSchema>> & {
+  theme: Theme
+  language: string
+}
 
 export type TEmailRequest = z.infer<ReturnType<typeof emailSchema>>
 
@@ -18,4 +22,6 @@ export type TUserResponse = {
   updatedAt: TTime
   defaultCurrency?: string
   numberFormat?: string
+  language?: string
+  theme?: Theme
 }

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -238,12 +238,15 @@
         "language": {
           "selector": "Language"
         },
-        "theme": {
-          "selector": "Theme",
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
-        }
+      "theme": {
+        "selector": "Theme",
+        "dark": "Dark",
+        "light": "Light",
+        "system": "System"
+      }
+      },
+      "toast": {
+        "updated": "Appearance updated successfully."
       }
     },
     "email": {

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -238,12 +238,15 @@
         "language": {
           "selector": "Bahasa"
         },
-        "theme": {
-          "selector": "Tema",
-          "dark": "Gelap",
-          "light": "Terang",
-          "system": "Sistem"
-        }
+      "theme": {
+        "selector": "Tema",
+        "dark": "Gelap",
+        "light": "Terang",
+        "system": "Sistem"
+      }
+      },
+      "toast": {
+        "updated": "Pengaturan tampilan berhasil diperbarui."
       }
     },
     "email": {

--- a/app/routes/_layout._main.tsx
+++ b/app/routes/_layout._main.tsx
@@ -1,7 +1,12 @@
-import { Outlet } from 'react-router'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Outlet, useRouteLoaderData } from 'react-router'
+
 
 import { fetchUserData } from '~/apis/firestore/user'
 import { Navbar } from '~/components/layouts/navbar'
+import { useTheme } from '~/lib/contexts/theme'
+import { TUserResponse } from '~/lib/types/user'
 
 export const clientLoader = async () => {
   try {
@@ -12,6 +17,18 @@ export const clientLoader = async () => {
 }
 
 const Dashboard = () => {
+  const userData = useRouteLoaderData<typeof clientLoader>('routes/_layout._main') as
+    | TUserResponse
+    | null
+  const { setTheme } = useTheme()
+  const { i18n } = useTranslation()
+
+  useEffect(() => {
+    if (!userData) return
+    if (userData.theme) setTheme(userData.theme)
+    if (userData.language) i18n.changeLanguage(userData.language)
+  }, [userData, setTheme, i18n])
+
   return (
     <main className="flex min-h-dvh w-full flex-col">
       <Navbar />


### PR DESCRIPTION
## Summary
- make language selector and mode toggle controllable
- keep previewed theme and language in component state
- revert to stored appearance if changes aren't saved
- add save button to persist language and theme together

## Testing
- `pnpm lint --fix`
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_6874a0f0f1548328ae8c38e7cc3c8653