### PR TITLE
Generate site.webmanifest during build

### DIFF
--- a/app/lib/hooks/use-update-appearance.ts
+++ b/app/lib/hooks/use-update-appearance.ts
@@ -5,7 +5,7 @@ import { useRevalidator } from 'react-router'
 
 import { updateAppearance } from '~/apis/firestore/user'
 import { authError } from '~/lib/constants/firebase'
-import { Theme } from '~/lib/contexts/theme'
+import { TUpdateAppearanceRequest } from '~/lib/types/settings'
 
 import { toast } from './use-toast'
 
@@ -16,7 +16,7 @@ export const useUpdateAppearance = () => {
   const [isError, setIsError] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
 
-  const mutate = async (data: { theme?: Theme; language?: string }) => {
+  const mutate = async (data: TUpdateAppearanceRequest) => {
     setIsPending(true)
     setIsError(false)
     setIsSuccess(false)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "build": "pnpm install && pnpm validate && cross-env NODE_ENV=production react-router build",
+    "build": "pnpm install && pnpm validate && node ./scripts/generate-manifest.mjs && cross-env NODE_ENV=production react-router build",
     "dev": "pnpm install && react-router dev",
     "lint": "eslint .",
+    "generate:manifest": "node ./scripts/generate-manifest.mjs",
     "preview": "vite preview",
     "typecheck": "react-router typegen && tsc",
     "format": "prettier --write .",

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Read metadata constants from the source file
+const metadataPath = new URL('../app/lib/constants/metadata.ts', import.meta.url)
+const metadataSource = readFileSync(metadataPath, 'utf8')
+
+const extract = (name, fallback) => {
+  const match = metadataSource.match(
+    new RegExp(`export const ${name} = ['\"]([^'\"]+)['\"]`)
+  )
+  return match?.[1] ?? fallback
+}
+
+const appName = extract('appName', 'App')
+const appleIcon = extract('appleIcon', '/apple-touch-icon.png')
+
+const manifest = {
+  name: appName,
+  short_name: appName,
+  icons: [
+    { src: '/android-chrome-192x192.png', sizes: '192x192', type: 'image/png' },
+    { src: '/android-chrome-512x512.png', sizes: '512x512', type: 'image/png' },
+    { src: appleIcon, sizes: '180x180', type: 'image/png' },
+  ],
+  theme_color: '#ffffff',
+  background_color: '#ffffff',
+  display: 'standalone',
+}
+
+const outputPath = join(process.cwd(), 'public', 'site.webmanifest')
+writeFileSync(outputPath, JSON.stringify(manifest))
+console.log(`Generated ${outputPath}`)
+


### PR DESCRIPTION
## Summary
- generate `public/site.webmanifest` automatically via a build script
- run the script as part of the build process
- fix `useUpdateAppearance` typings
- derive manifest data from constants

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_6875096c07488328a801a3c101f5ed9e