### PR TITLE
Add profile photo update

### DIFF
--- a/app/components/pages/general-settings/index.tsx
+++ b/app/components/pages/general-settings/index.tsx
@@ -1,9 +1,11 @@
 import { Appearance } from './appearance'
+import { Photo } from './photo'
 import { Profile } from './profile'
 
 export const GeneralSettingsPage = () => {
   return (
     <div className="grid gap-6">
+      <Photo />
       <Profile />
       <Appearance />
     </div>

--- a/app/components/pages/general-settings/photo.tsx
+++ b/app/components/pages/general-settings/photo.tsx
@@ -1,0 +1,82 @@
+import { CircleUser } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '~/components/base/button'
+import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card'
+import { useUserData } from '~/lib/hooks/use-get-user'
+import { useUpdatePhoto } from '~/lib/hooks/use-update-photo'
+
+export const Photo = () => {
+  const { t } = useTranslation()
+  const { data: userData } = useUserData()
+  const { mutate, isPending, isSuccess, isError } = useUpdatePhoto()
+  const [file, setFile] = useState<File>()
+  const [disabled, setDisabled] = useState(false)
+  const fileInputReference = useRef<HTMLInputElement>(null)
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files[0]) {
+      setFile(event.target.files[0])
+    }
+  }
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!file) return
+    setDisabled(true)
+    await mutate(file)
+  }
+
+  useEffect(() => {
+    if (isSuccess || isError) {
+      setDisabled(false)
+      setFile(undefined)
+      if (fileInputReference.current) fileInputReference.current.value = ''
+    }
+  }, [isSuccess, isError])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('settings.photo.title')}</CardTitle>
+        <CardDescription>{t('settings.photo.description')}</CardDescription>
+      </CardHeader>
+      <form onSubmit={onSubmit}>
+        <CardContent className="flex items-end space-x-4">
+          <Avatar className="h-16 w-16">
+            <AvatarImage src={userData?.photoURL || ''} />
+            <AvatarFallback>
+              <CircleUser className="h-8 w-8" />
+            </AvatarFallback>
+          </Avatar>
+          <input
+            ref={fileInputReference}
+            type="file"
+            accept="image/*"
+            onChange={handleChange}
+            disabled={disabled}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+          />
+        </CardContent>
+        <CardFooter className="border-t px-6 py-4">
+          <Button
+            disabled={!file || disabled}
+            isLoading={isPending}
+            type="submit"
+          >
+            {t('form.save')}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/app/lib/hooks/use-update-photo.ts
+++ b/app/lib/hooks/use-update-photo.ts
@@ -1,0 +1,47 @@
+import { FirebaseError } from 'firebase/app'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRevalidator } from 'react-router'
+
+import { updatePhoto } from '~/apis/firestore/user'
+import { authError } from '~/lib/constants/firebase'
+
+import { toast } from './use-toast'
+
+export const useUpdatePhoto = () => {
+  const { revalidate } = useRevalidator()
+  const { t } = useTranslation()
+  const [isPending, setIsPending] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const mutate = async (file: File) => {
+    setIsPending(true)
+    setIsError(false)
+    setIsSuccess(false)
+    try {
+      await updatePhoto(file)
+      toast({
+        description: t('auth.toast.photoUpdated'),
+      })
+      setIsSuccess(true)
+      revalidate()
+    } catch (error: unknown) {
+      setIsError(true)
+      let message = String(error)
+      if (error instanceof FirebaseError) {
+        message =
+          authError.find((item) => item.code === error.code)?.message ||
+          error.message
+      }
+      toast({
+        variant: 'destructive',
+        description: message,
+      })
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return { mutate, isPending, isError, isSuccess }
+}

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -99,7 +99,8 @@
       "linkGoogle": "Your Google account has been linked successfully.",
       "emailVerify": "Please check your email to verify your account.",
       "updateEmail": "Please check your email to verify the new email address.",
-      "profileUpdated": "Your profile has been updated successfully."
+      "profileUpdated": "Your profile has been updated successfully.",
+      "photoUpdated": "Your profile photo has been updated."
     }
   },
   "notes": {
@@ -231,6 +232,10 @@
       "title": "Profile",
       "description": "Update your profile information."
     },
+    "photo": {
+      "title": "Profile Photo",
+      "description": "Update your profile picture."
+    },
     "appearance": {
       "title": "Appearance",
       "description": "Customize the appearance of <span>{{appName}}</span>.",
@@ -238,12 +243,12 @@
         "language": {
           "selector": "Language"
         },
-      "theme": {
-        "selector": "Theme",
-        "dark": "Dark",
-        "light": "Light",
-        "system": "System"
-      }
+        "theme": {
+          "selector": "Theme",
+          "dark": "Dark",
+          "light": "Light",
+          "system": "System"
+        }
       },
       "toast": {
         "updated": "Appearance updated successfully."

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -99,7 +99,8 @@
       "linkGoogle": "Akun Google Anda telah terhubung.",
       "emailVerify": "Silakan cek email Anda untuk verifikasi akun.",
       "updateEmail": "Silakan cek email Anda untuk verifikasi alamat email baru.",
-      "profileUpdated": "Profil Anda telah diperbarui."
+      "profileUpdated": "Profil Anda telah diperbarui.",
+      "photoUpdated": "Foto profil Anda telah diperbarui."
     }
   },
   "notes": {
@@ -231,6 +232,10 @@
       "title": "Profil",
       "description": "Perbarui informasi profil Anda."
     },
+    "photo": {
+      "title": "Foto Profil",
+      "description": "Perbarui foto profil Anda."
+    },
     "appearance": {
       "title": "Tampilan",
       "description": "Atur tampilan <span>{{appName}}</span>.",
@@ -238,12 +243,12 @@
         "language": {
           "selector": "Bahasa"
         },
-      "theme": {
-        "selector": "Tema",
-        "dark": "Gelap",
-        "light": "Terang",
-        "system": "Sistem"
-      }
+        "theme": {
+          "selector": "Tema",
+          "dark": "Gelap",
+          "light": "Terang",
+          "system": "Sistem"
+        }
       },
       "toast": {
         "updated": "Pengaturan tampilan berhasil diperbarui."


### PR DESCRIPTION
## Summary
- initialize Firebase storage
- add API and hook for updating user photo
- create settings screen to upload photo
- update translations

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_68751df028e88328b0ff8a750a48d9ba