### PR TITLE
Add deletable tasks inline

### DIFF
--- a/app/components/base/checkbox/index.tsx
+++ b/app/components/base/checkbox/index.tsx
@@ -32,6 +32,7 @@ export const Checkbox = <TFormValues extends Record<string, unknown>>(
     inputClassName,
     textareaContainerClassName,
     textareaClassName,
+    rightNode: RightNode,
     required,
     rows,
     readOnly,
@@ -57,7 +58,10 @@ export const Checkbox = <TFormValues extends Record<string, unknown>>(
               />
             </FormControl>
             {label ? (
-              <FormLabel htmlFor={id} className={labelClassName}>
+              <FormLabel
+                htmlFor={id}
+                className={labelClassName}
+              >
                 {label} {required && <sup className="text-red-500">*</sup>}
               </FormLabel>
             ) : (
@@ -70,6 +74,7 @@ export const Checkbox = <TFormValues extends Record<string, unknown>>(
                   rows={rows}
                   readOnly={readOnly}
                   onKeyDown={onKeyDown}
+                  rightNode={RightNode}
                 />
               )
             )}

--- a/app/components/base/checkbox/type.ts
+++ b/app/components/base/checkbox/type.ts
@@ -22,6 +22,7 @@ export type TProperties<TFormValues extends FieldValues> = {
   inputClassName?: ComponentPropsWithoutRef<typeof Checkbox>['className']
   textareaContainerClassName?: HTMLAttributes<HTMLDivElement>['className']
   textareaClassName?: HTMLAttributes<HTMLTextAreaElement>['className']
+  rightNode?: (properties: HTMLAttributes<HTMLDivElement>) => ReactNode
   required?: boolean
   rows?: TextareaHTMLAttributes<HTMLTextAreaElement>['rows']
   readOnly?: boolean

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -17,6 +17,7 @@ import { useUserData } from '~/lib/hooks/use-get-user'
 import { useUpdateTask } from '~/lib/hooks/use-update-task'
 import { TTaskForm } from '~/lib/types/task'
 import { getDateLabel } from '~/lib/utils/parser'
+import { cn } from '~/lib/utils/shadcn'
 import { taskSchema } from '~/lib/validations/task'
 
 import { TFormProperties } from './type'
@@ -193,22 +194,26 @@ export const Form = forwardRef((properties: TFormProperties, reference) => {
               }}
               disabled={task && !isEditable}
               className="m-0"
+              rightNode={
+                isEditable
+                  ? ({ className }) => (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className={cn(className, 'h-4 w-4 p-0')}
+                        onClick={() => remove(index)}
+                      >
+                        <Trash className="h-3 w-3" />
+                      </Button>
+                    )
+                  : undefined
+              }
             />
             <input
               type="hidden"
               {...formMethods.register(`content.${index}.sequence`)}
               value={index}
             />
-            {isEditable && (
-              <Button
-                type="button"
-                variant="ghost"
-                className="h-4 w-4 p-0"
-                onClick={() => remove(index)}
-              >
-                <Trash className="h-3 w-3" />
-              </Button>
-            )}
           </div>
         ))}
         {isEditable && (


### PR DESCRIPTION
## Summary
- allow Checkbox to render a right node element
- hook up delete button as part of checkbox in task detail form

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_687622dd093483289e127d5dc49d5725