### PR TITLE
Fix React Hook Form setFocus with Textarea

### DIFF
--- a/app/components/base/textarea/index.tsx
+++ b/app/components/base/textarea/index.tsx
@@ -69,6 +69,7 @@ export const Textarea = <TFormValues extends Record<string, unknown>>(
                 }}
                 {...field}
                 ref={(textarea) => {
+                  field.ref(textarea)
                   if (textarea) {
                     textarea.style.height = 'auto'
                     textarea.style.height = `${textarea.scrollHeight}px`


### PR DESCRIPTION
## Summary
- ensure Textarea passes field.ref so `setFocus` works on tasks

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_6876859273088328884e8c26ad5291bc