### PR TITLE
Fix task form debounce

### DIFF
--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -83,6 +83,7 @@ export const Form = forwardRef((properties: TFormProperties, reference) => {
     setFocus,
   } = formMethods
   const watchTitle = watch('title')
+  const watchContent = watch('content')
 
   const focusIndexReference = useRef<number | null>(null)
 
@@ -112,7 +113,7 @@ export const Form = forwardRef((properties: TFormProperties, reference) => {
 
   useDebounce({
     trigger: () => onSubmit(),
-    watch: [watchTitle],
+    watch: [watchTitle, watchContent],
     condition: !!selectedTask,
   })
 

--- a/app/lib/hooks/use-debounce.ts
+++ b/app/lib/hooks/use-debounce.ts
@@ -1,9 +1,9 @@
-import { ReactNode, useEffect } from 'react'
+import { useEffect, type DependencyList } from 'react'
 
 type TProperties = {
   trigger: () => void
   condition?: boolean
-  watch: ReactNode[]
+  watch: DependencyList
 }
 
 export const useDebounce = (properties: TProperties) => {
@@ -17,5 +17,5 @@ export const useDebounce = (properties: TProperties) => {
 
     return () => clearTimeout(delayDebounceFunction)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...watch])
+  }, watch)
 }


### PR DESCRIPTION
## Summary
- watch task content in `useDebounce` hook so edits autosave
- update generic `useDebounce` hook to accept React `DependencyList`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_6876ddf3eb448328a0199138ed2f3923