### PR TITLE
Fix isDirty detection for task form

### DIFF
--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -63,13 +63,15 @@ export const Form = (properties: TFormProperties) => {
     resolver: zodResolver(taskSchema),
     values: {
       title: selectedTask?.title || '',
-      content: selectedTask?.content || [
-        {
-          sequence: 1,
-          checked: false,
-          description: '',
-        },
-      ],
+      content: selectedTask?.content
+        ? selectedTask.content.map((item) => ({ ...item }))
+        : [
+            {
+              sequence: 1,
+              checked: false,
+              description: '',
+            },
+          ],
     },
   })
   const {


### PR DESCRIPTION
## Summary
- fix form default values to use copies of task content

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_68771dcffc5883289d0e0d805d75aee1