### PR TITLE
Implement 100 hidden task checkboxes

### DIFF
--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -8,6 +8,8 @@ import { Action } from '~/components/base/action'
 import { Checkbox } from '~/components/base/checkbox'
 import { Textarea } from '~/components/base/textarea'
 import { useTask } from '~/components/pages/tasks'
+import { Checkbox as UICheckbox } from '~/components/ui/checkbox'
+import { Textarea as UITextarea } from '~/components/ui/textarea'
 import { auth } from '~/lib/configs/firebase'
 import { useCreateTask } from '~/lib/hooks/use-create-task'
 import { useDebounce } from '~/lib/hooks/use-debounce'
@@ -15,12 +17,14 @@ import { useUserData } from '~/lib/hooks/use-get-user'
 import { useUpdateTask } from '~/lib/hooks/use-update-task'
 import { TTaskForm } from '~/lib/types/task'
 import { getDateLabel } from '~/lib/utils/parser'
+import { cn } from '~/lib/utils/shadcn'
 import { taskSchema } from '~/lib/validations/task'
 
 import { TFormProperties } from './type'
 
 export const Form = (properties: TFormProperties) => {
   const { tasks } = properties
+  const MAX_CONTENT_ITEMS = 100
   const { t, i18n } = useTranslation()
   const {
     selectedTask,
@@ -161,82 +165,95 @@ export const Form = (properties: TFormProperties) => {
           }}
           readOnly={task && !isEditable}
         />
-        {fields.map((field, index) => (
-          <div
-            key={field.id}
-            className="flex items-start gap-2"
-          >
-            <Checkbox
-              name={`content.${index}.checked`}
-              disabled={task && !isEditable}
-              className="m-0"
-              leftNode={
-                <input
-                  type="hidden"
-                  name={`content.${index}.sequence`}
-                  value={index}
+        {Array.from({ length: MAX_CONTENT_ITEMS }).map((_, index) => {
+          const field = fields[index]
+          const hidden = index >= fields.length
+          return (
+            <div
+              key={field?.id ?? `hidden-${index}`}
+              className={cn('flex items-start gap-2', hidden && 'hidden')}
+            >
+              {hidden ? (
+                <>
+                  <UICheckbox disabled className="m-0" />
+                  <UITextarea disabled className="hidden" />
+                </>
+              ) : (
+                <Checkbox
+                  name={`content.${index}.checked`}
+                  disabled={task && !isEditable}
+                  className="m-0"
+                  leftNode={
+                    <input
+                      type="hidden"
+                      name={`content.${index}.sequence`}
+                      value={index}
+                    />
+                  }
+                  rightNode={
+                    <Textarea
+                      name={`content.${index}.item`}
+                      placeholder={t('tasks.form.item.label')}
+                      containerClassName="flex-1"
+                      inputClassName="border-none ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 rounded-none p-0 focus-visible:shadow-none focus:outline-none resize-none min-h-fit"
+                      rows={1}
+                      readOnly={task && !isEditable}
+                      onKeyDown={(event) => {
+                        const isEnter = event.key === 'Enter'
+                        const isBackspace = event.key === 'Backspace'
+                        const isArrowUp = event.key === 'ArrowUp'
+                        const isArrowDown = event.key === 'ArrowDown'
+                        const isEmpty = !getValues(`content.${index}.item`)
+
+                        if (isEnter) {
+                          event.preventDefault()
+                          if (index === fields.length - 1) {
+                            if (fields.length < MAX_CONTENT_ITEMS) {
+                              focusIndexReference.current = fields.length
+                              append({
+                                sequence: fields.length,
+                                checked: false,
+                                item: '',
+                              })
+                            }
+                          } else {
+                            setFocus(`content.${index + 1}.item`)
+                          }
+                        }
+
+                        if (isBackspace && isEmpty) {
+                          event.preventDefault()
+                          if (fields.length > 1) {
+                            focusIndexReference.current = Math.max(0, index - 1)
+                            remove(index)
+                          } else {
+                            setFocus('title')
+                          }
+                        }
+
+                        if (isArrowUp) {
+                          event.preventDefault()
+                          if (index > 0) {
+                            setFocus(`content.${index - 1}.item`)
+                          } else {
+                            setFocus('title')
+                          }
+                        }
+
+                        if (isArrowDown) {
+                          event.preventDefault()
+                          if (index < fields.length - 1) {
+                            setFocus(`content.${index + 1}.item`)
+                          }
+                        }
+                      }}
+                    />
+                  }
                 />
-              }
-              rightNode={
-                <Textarea
-                  name={`content.${index}.item`}
-                  placeholder={t('tasks.form.item.label')}
-                  containerClassName="flex-1"
-                  inputClassName="border-none ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 rounded-none p-0 focus-visible:shadow-none focus:outline-none resize-none min-h-fit"
-                  rows={1}
-                  readOnly={task && !isEditable}
-                  onKeyDown={(event) => {
-                    const isEnter = event.key === 'Enter'
-                    const isBackspace = event.key === 'Backspace'
-                    const isArrowUp = event.key === 'ArrowUp'
-                    const isArrowDown = event.key === 'ArrowDown'
-                    const isEmpty = !getValues(`content.${index}.item`)
-
-                    if (isEnter) {
-                      event.preventDefault()
-                      if (index === fields.length - 1) {
-                        focusIndexReference.current = fields.length
-                        append({
-                          sequence: fields.length,
-                          checked: false,
-                          item: '',
-                        })
-                      } else {
-                        setFocus(`content.${index + 1}.item`)
-                      }
-                    }
-
-                    if (isBackspace && isEmpty) {
-                      event.preventDefault()
-                      if (fields.length > 1) {
-                        focusIndexReference.current = Math.max(0, index - 1)
-                        remove(index)
-                      } else {
-                        setFocus('title')
-                      }
-                    }
-
-                    if (isArrowUp) {
-                      event.preventDefault()
-                      if (index > 0) {
-                        setFocus(`content.${index - 1}.item`)
-                      } else {
-                        setFocus('title')
-                      }
-                    }
-
-                    if (isArrowDown) {
-                      event.preventDefault()
-                      if (index < fields.length - 1) {
-                        setFocus(`content.${index + 1}.item`)
-                      }
-                    }
-                  }}
-                />
-              }
-            />
-          </div>
-        ))}
+              )}
+            </div>
+          )
+        })}
       </form>
       <span className="flex justify-center text-xs text-muted-foreground">
         <span>


### PR DESCRIPTION
## Summary
- prepopulate task form with up to 100 checkboxes
- hide and disable unused placeholders

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_6878657c69288328a8bc26f0a108e11c