### PR TITLE
Fix mobile navigation closing issue

### DIFF
--- a/app/components/layouts/navbar/index.tsx
+++ b/app/components/layouts/navbar/index.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { CircleUser, Menu, Search } from 'lucide-react'
+import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
@@ -29,6 +30,7 @@ import { TProperties } from './type'
 
 export const Navbar = (properties: TProperties) => {
   const { className } = properties
+  const [open, setOpen] = useState(false)
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { data: userData } = useUserData()
@@ -60,7 +62,10 @@ export const Navbar = (properties: TProperties) => {
       )}
     >
       <Navigation className="hidden flex-col md:flex md:flex-row md:items-center md:gap-5 md:text-sm lg:gap-6" />
-      <Sheet>
+      <Sheet
+        open={open}
+        onOpenChange={setOpen}
+      >
         <SheetTrigger asChild>
           <Button
             variant="outline"
@@ -72,7 +77,10 @@ export const Navbar = (properties: TProperties) => {
           </Button>
         </SheetTrigger>
         <SheetContent side="left">
-          <Navigation className="grid" />
+          <Navigation
+            className="grid"
+            onLinkClick={() => setOpen(false)}
+          />
         </SheetContent>
       </Sheet>
       <div className="flex w-full items-center gap-4 md:ml-auto md:gap-2 lg:gap-4">

--- a/app/components/layouts/navbar/navigation.tsx
+++ b/app/components/layouts/navbar/navigation.tsx
@@ -8,7 +8,7 @@ import { navs } from './constant'
 import { TProperties } from './type'
 
 export const Navigation = (properties: TProperties) => {
-  const { className } = properties
+  const { className, onLinkClick } = properties
   const { pathname } = useLocation()
   const { t } = useTranslation()
 
@@ -16,6 +16,7 @@ export const Navigation = (properties: TProperties) => {
     <nav className={cn('gap-6 text-lg font-medium', className)}>
       <Link
         to="#"
+        onClick={onLinkClick}
         className="flex items-center gap-2 whitespace-nowrap text-lg font-semibold md:text-base"
       >
         <div className="relative h-6 w-6">
@@ -34,6 +35,7 @@ export const Navigation = (properties: TProperties) => {
         <Link
           key={index}
           to={nav.href}
+          onClick={onLinkClick}
           className={cn(
             pathname === nav.href ? 'text-foreground' : 'text-muted-foreground',
             'whitespace-nowrap transition-colors hover:text-foreground',

--- a/app/components/layouts/navbar/type.ts
+++ b/app/components/layouts/navbar/type.ts
@@ -2,4 +2,5 @@ import { HTMLAttributes } from 'react'
 
 export type TProperties = {
   className?: HTMLAttributes<HTMLDivElement>['className']
+  onLinkClick?: () => void
 }


### PR DESCRIPTION
## Summary
- close the mobile navigation Sheet when a link is clicked

## Testing
- `pnpm validate` *(fails: pnpm not found before Node setup)*

------
https://chatgpt.com/codex/tasks/task_e_68799a9078848328bd7fc9a6160d6ae7