### PR TITLE
Handle missing notes/tasks and add redirect

### DIFF
--- a/app/components/layouts/root/index.tsx
+++ b/app/components/layouts/root/index.tsx
@@ -17,7 +17,7 @@ import { middleware } from '~/lib/utils/middleware'
 
 export const Rootlayout = (properties: PropsWithChildren) => {
   const { children } = properties
-  const { pathname } = useLocation()
+  const location = useLocation()
   const { isLoading } = useFirebase()
   const { data: user, isLoading: userIsLoading } = useAuthUser()
   const navigate = useNavigate()
@@ -25,8 +25,8 @@ export const Rootlayout = (properties: PropsWithChildren) => {
 
   useEffect(() => {
     if (userIsLoading) return
-    middleware({ user, navigate, pathname })
-  }, [user, userIsLoading, navigate, pathname])
+    middleware({ user, navigate, location })
+  }, [user, userIsLoading, navigate, location])
 
   return (
     <html

--- a/app/components/pages/note-detail/content.tsx
+++ b/app/components/pages/note-detail/content.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 
 import { LoadingScreen } from '~/components/base/loading-screen'
 import { Modal } from '~/components/base/modal'
@@ -8,6 +8,7 @@ import { Share } from '~/components/base/share'
 import { useNote } from '~/components/pages/notes'
 import { useGetNotes } from '~/lib/hooks/use-get-notes'
 import { useShareNote } from '~/lib/hooks/use-share-note'
+import { toast } from '~/lib/hooks/use-toast'
 import {
   THandleDeletePermission,
   THandleSetPermission,
@@ -19,6 +20,7 @@ import { Form } from './form'
 export const Content = () => {
   const { note } = useParams()
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const { data: notes } = useGetNotes()
   const {
     setSelectedNote,
@@ -37,6 +39,18 @@ export const Content = () => {
   useEffect(() => {
     if (current) setSelectedNote(current)
   }, [current, setSelectedNote])
+
+  useEffect(() => {
+    if (notes && note !== 'create' && !current) {
+      toast({
+        variant: 'destructive',
+        description: t('notes.toast.notFound', {
+          defaultValue: "Note not found or you don't have access",
+        }),
+      })
+      navigate('/notes/create', { replace: true })
+    }
+  }, [notes, note, current, navigate, t])
 
   const handleShare = (parameters: THandleSetPermission) => {
     const data = {

--- a/app/components/pages/task-detail/content.tsx
+++ b/app/components/pages/task-detail/content.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 
 import { LoadingScreen } from '~/components/base/loading-screen'
 import { Modal } from '~/components/base/modal'
@@ -8,6 +8,7 @@ import { Share } from '~/components/base/share'
 import { useTask } from '~/components/pages/tasks'
 import { useGetTasks } from '~/lib/hooks/use-get-tasks'
 import { useShareTask } from '~/lib/hooks/use-share-task'
+import { toast } from '~/lib/hooks/use-toast'
 import {
   THandleDeletePermission,
   THandleSetPermission,
@@ -19,6 +20,7 @@ import { Form } from './form'
 export const Content = () => {
   const { task } = useParams()
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const { data: tasks } = useGetTasks()
   const {
     setSelectedTask,
@@ -37,6 +39,18 @@ export const Content = () => {
   useEffect(() => {
     if (current) setSelectedTask(current)
   }, [current, setSelectedTask])
+
+  useEffect(() => {
+    if (tasks && task !== 'create' && !current) {
+      toast({
+        variant: 'destructive',
+        description: t('tasks.toast.notFound', {
+          defaultValue: "Task not found or you don't have access",
+        }),
+      })
+      navigate('/tasks/create', { replace: true })
+    }
+  }, [tasks, task, current, navigate, t])
 
   const handleShare = (parameters: THandleSetPermission) => {
     const data = {

--- a/app/lib/configs/page.ts
+++ b/app/lib/configs/page.ts
@@ -1,3 +1,3 @@
-export const protectedPages = new Set(['/', '/notes'])
+export const protectedPages = new Set(['/', '/notes', '/tasks'])
 
 export const authPages = new Set(['/', '/auth'])

--- a/app/lib/utils/middleware.ts
+++ b/app/lib/utils/middleware.ts
@@ -1,26 +1,30 @@
 import { User } from 'firebase/auth'
-import { NavigateFunction } from 'react-router'
+import { NavigateFunction, type Location } from 'react-router'
 
 import { authPages, protectedPages } from '~/lib/configs/page'
 import { extractPathSegment } from '~/lib/utils/parser'
 
 type TProperties = {
   navigate: NavigateFunction
-  pathname: string
+  location: Location
   user?: User | null
 }
 
 export const middleware = (properties: TProperties) => {
-  const { navigate, pathname, user } = properties
+  const { navigate, location, user } = properties
+  const { pathname, search } = location
   const extractedPath = extractPathSegment(pathname)
 
   if (protectedPages.has(extractedPath) && !user) {
-    const url = '/auth/sign-in'
+    const url = `/auth/sign-in?redirect=${encodeURIComponent(
+      pathname + search,
+    )}`
     return navigate(url)
   }
 
   if (authPages.has(extractedPath) && user) {
-    const url = '/notes'
+    const redirect = new URLSearchParams(search).get('redirect')
+    const url = redirect || '/notes'
     return navigate(url)
   }
 }

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -116,7 +116,8 @@
     },
     "toast": {
       "deleted": "Note deleted successfully",
-      "created": "Note created successfully"
+      "created": "Note created successfully",
+      "notFound": "Note not found or you don't have access"
     }
   },
   "tasks": {
@@ -133,7 +134,8 @@
     },
     "toast": {
       "deleted": "Task deleted successfully",
-      "created": "Task created successfully"
+      "created": "Task created successfully",
+      "notFound": "Task not found or you don't have access"
     }
   },
   "moneyLog": {

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -116,7 +116,8 @@
     },
     "toast": {
       "deleted": "Catatan berhasil dihapus",
-      "created": "Catatan berhasil dibuat"
+      "created": "Catatan berhasil dibuat",
+      "notFound": "Catatan tidak ditemukan atau Anda tidak memiliki akses"
     }
   },
   "tasks": {
@@ -133,7 +134,8 @@
     },
     "toast": {
       "deleted": "Tugas berhasil dihapus",
-      "created": "Tugas berhasil dibuat"
+      "created": "Tugas berhasil dibuat",
+      "notFound": "Tugas tidak ditemukan atau Anda tidak memiliki akses"
     }
   },
   "moneyLog": {


### PR DESCRIPTION
## Summary
- redirect unauthenticated users back to requested page after login
- show toast and redirect to creation when note or task not accessible
- localize new toast messages

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687a3801e3b083289a6b47a1eb3a9438