### PR TITLE
Fix unauthorized detail redirect

### DIFF
--- a/app/components/pages/note-detail/content.tsx
+++ b/app/components/pages/note-detail/content.tsx
@@ -6,7 +6,9 @@ import { LoadingScreen } from '~/components/base/loading-screen'
 import { Modal } from '~/components/base/modal'
 import { Share } from '~/components/base/share'
 import { useNote } from '~/components/pages/notes'
+import { useAuthUser } from '~/lib/hooks/use-auth-user'
 import { useGetNotes } from '~/lib/hooks/use-get-notes'
+import { useLogout } from '~/lib/hooks/use-logout'
 import { useShareNote } from '~/lib/hooks/use-share-note'
 import { toast } from '~/lib/hooks/use-toast'
 import {
@@ -22,6 +24,8 @@ export const Content = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { data: notes } = useGetNotes()
+  const { data: user, isLoading: userIsLoading } = useAuthUser()
+  const { mutate: mutateLogout } = useLogout()
   const {
     setSelectedNote,
     openConfirmation,
@@ -42,6 +46,11 @@ export const Content = () => {
 
   useEffect(() => {
     if (notes && note !== 'create' && !current) {
+      if (!user && !userIsLoading) {
+        mutateLogout()
+        return
+      }
+
       toast({
         variant: 'destructive',
         description: t('notes.toast.notFound', {
@@ -50,7 +59,7 @@ export const Content = () => {
       })
       navigate('/notes/create', { replace: true })
     }
-  }, [notes, note, current, navigate, t])
+  }, [notes, note, current, navigate, t, user, userIsLoading, mutateLogout])
 
   const handleShare = (parameters: THandleSetPermission) => {
     const data = {

--- a/app/components/pages/task-detail/content.tsx
+++ b/app/components/pages/task-detail/content.tsx
@@ -6,7 +6,9 @@ import { LoadingScreen } from '~/components/base/loading-screen'
 import { Modal } from '~/components/base/modal'
 import { Share } from '~/components/base/share'
 import { useTask } from '~/components/pages/tasks'
+import { useAuthUser } from '~/lib/hooks/use-auth-user'
 import { useGetTasks } from '~/lib/hooks/use-get-tasks'
+import { useLogout } from '~/lib/hooks/use-logout'
 import { useShareTask } from '~/lib/hooks/use-share-task'
 import { toast } from '~/lib/hooks/use-toast'
 import {
@@ -22,6 +24,8 @@ export const Content = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { data: tasks } = useGetTasks()
+  const { data: user, isLoading: userIsLoading } = useAuthUser()
+  const { mutate: mutateLogout } = useLogout()
   const {
     setSelectedTask,
     openConfirmation,
@@ -42,6 +46,11 @@ export const Content = () => {
 
   useEffect(() => {
     if (tasks && task !== 'create' && !current) {
+      if (!user && !userIsLoading) {
+        mutateLogout()
+        return
+      }
+
       toast({
         variant: 'destructive',
         description: t('tasks.toast.notFound', {
@@ -50,7 +59,7 @@ export const Content = () => {
       })
       navigate('/tasks/create', { replace: true })
     }
-  }, [tasks, task, current, navigate, t])
+  }, [tasks, task, current, navigate, t, user, userIsLoading, mutateLogout])
 
   const handleShare = (parameters: THandleSetPermission) => {
     const data = {


### PR DESCRIPTION
## Summary
- trigger logout when unauthenticated users visit a note/task detail instead of redirecting to create page

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687a416bf97c832894ca4afdc01eeff0