### PR TITLE
Add OAuth consent pages

### DIFF
--- a/app/components/pages/about/index.tsx
+++ b/app/components/pages/about/index.tsx
@@ -7,10 +7,7 @@ export const AboutPage = () => {
   return (
     <main className="flex flex-1 flex-col gap-4 bg-muted/40 p-4 md:gap-8 md:p-8">
       <h1 className="text-3xl font-semibold">{t('navigation.about')}</h1>
-      <p>
-        {appName} is a personal productivity application that helps you manage
-        tasks, notes, and finances in one place.
-      </p>
+      <p>{t('about.description', { appName })}</p>
     </main>
   )
 }

--- a/app/components/pages/about/index.tsx
+++ b/app/components/pages/about/index.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next'
+
+import { appName } from '~/lib/constants/metadata'
+
+export const AboutPage = () => {
+  const { t } = useTranslation()
+  return (
+    <main className="flex flex-1 flex-col gap-4 bg-muted/40 p-4 md:gap-8 md:p-8">
+      <h1 className="text-3xl font-semibold">{t('navigation.about')}</h1>
+      <p>
+        {appName} is a personal productivity application that helps you manage
+        tasks, notes, and finances in one place.
+      </p>
+    </main>
+  )
+}

--- a/app/components/pages/privacy-policy/index.tsx
+++ b/app/components/pages/privacy-policy/index.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next'
+
+export const PrivacyPolicyPage = () => {
+  const { t } = useTranslation()
+  return (
+    <main className="flex flex-1 flex-col gap-4 bg-muted/40 p-4 md:gap-8 md:p-8">
+      <h1 className="text-3xl font-semibold">
+        {t('navigation.privacyPolicy')}
+      </h1>
+      <p>
+        We respect your privacy and do not share your personal information with
+        third parties except as required to provide our services.
+      </p>
+    </main>
+  )
+}

--- a/app/components/pages/privacy-policy/index.tsx
+++ b/app/components/pages/privacy-policy/index.tsx
@@ -7,10 +7,7 @@ export const PrivacyPolicyPage = () => {
       <h1 className="text-3xl font-semibold">
         {t('navigation.privacyPolicy')}
       </h1>
-      <p>
-        We respect your privacy and do not share your personal information with
-        third parties except as required to provide our services.
-      </p>
+      <p>{t('privacyPolicy.description')}</p>
     </main>
   )
 }

--- a/app/components/pages/sign-in/index.tsx
+++ b/app/components/pages/sign-in/index.tsx
@@ -162,6 +162,28 @@ export const SignInPage = () => {
             <Link to="/auth/sign-up">{t('auth.signIn.form.switch.link')}</Link>
           </UIButton>
         </div>
+        <div className="space-x-2 text-center text-xs text-muted-foreground">
+          <Link
+            to="/about"
+            className="hover:underline"
+          >
+            {t('navigation.about')}
+          </Link>
+          <span>&middot;</span>
+          <Link
+            to="/privacy-policy"
+            className="hover:underline"
+          >
+            {t('navigation.privacyPolicy')}
+          </Link>
+          <span>&middot;</span>
+          <Link
+            to="/terms-of-service"
+            className="hover:underline"
+          >
+            {t('navigation.termsOfService')}
+          </Link>
+        </div>
       </CardFooter>
     </Card>
   )

--- a/app/components/pages/terms-of-service/index.tsx
+++ b/app/components/pages/terms-of-service/index.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next'
+
+export const TermsOfServicePage = () => {
+  const { t } = useTranslation()
+  return (
+    <main className="flex flex-1 flex-col gap-4 bg-muted/40 p-4 md:gap-8 md:p-8">
+      <h1 className="text-3xl font-semibold">
+        {t('navigation.termsOfService')}
+      </h1>
+      <p>
+        By using this application you agree to abide by our terms of service and
+        use the application responsibly.
+      </p>
+    </main>
+  )
+}

--- a/app/components/pages/terms-of-service/index.tsx
+++ b/app/components/pages/terms-of-service/index.tsx
@@ -7,10 +7,7 @@ export const TermsOfServicePage = () => {
       <h1 className="text-3xl font-semibold">
         {t('navigation.termsOfService')}
       </h1>
-      <p>
-        By using this application you agree to abide by our terms of service and
-        use the application responsibly.
-      </p>
+      <p>{t('termsOfService.description')}</p>
     </main>
   )
 }

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -250,6 +250,15 @@
       }
     }
   },
+  "about": {
+    "description": "{{appName}} is a personal productivity application that helps you manage tasks, notes, and finances in one place."
+  },
+  "privacyPolicy": {
+    "description": "We respect your privacy and do not share your personal information with third parties except as required to provide our services."
+  },
+  "termsOfService": {
+    "description": "By using this application you agree to abide by our terms of service and use the application responsibly."
+  },
   "settings": {
     "profile": {
       "title": "Profile",

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -12,6 +12,9 @@
     "account": "Account",
     "reportIssues": "Report Issues",
     "changelog": "Changelog",
+    "about": "About",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
     "signOut": "Sign Out",
     "search": {
       "placeholder": "Search"

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -12,6 +12,9 @@
     "account": "Akun",
     "reportIssues": "Laporkan Masalah",
     "changelog": "Catatan Perubahan",
+    "about": "Tentang Aplikasi",
+    "privacyPolicy": "Kebijakan Privasi",
+    "termsOfService": "Syarat Layanan",
     "signOut": "Keluar",
     "search": {
       "placeholder": "Cari"

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -250,6 +250,15 @@
       }
     }
   },
+  "about": {
+    "description": "{{appName}} adalah aplikasi produktivitas pribadi yang membantu Anda mengelola tugas, catatan, dan keuangan dalam satu tempat."
+  },
+  "privacyPolicy": {
+    "description": "Kami menghormati privasi Anda dan tidak membagikan informasi pribadi Anda kepada pihak ketiga kecuali untuk menyediakan layanan kami."
+  },
+  "termsOfService": {
+    "description": "Dengan menggunakan aplikasi ini Anda setuju untuk mematuhi syarat layanan kami dan menggunakan aplikasi dengan bertanggung jawab."
+  },
   "settings": {
     "profile": {
       "title": "Profil",

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,0 +1,5 @@
+import { AboutPage } from '~/components/pages/about'
+
+const About = () => <AboutPage />
+
+export default About

--- a/app/routes/privacy-policy.tsx
+++ b/app/routes/privacy-policy.tsx
@@ -1,0 +1,5 @@
+import { PrivacyPolicyPage } from '~/components/pages/privacy-policy'
+
+const PrivacyPolicy = () => <PrivacyPolicyPage />
+
+export default PrivacyPolicy

--- a/app/routes/terms-of-service.tsx
+++ b/app/routes/terms-of-service.tsx
@@ -1,0 +1,5 @@
+import { TermsOfServicePage } from '~/components/pages/terms-of-service'
+
+const TermsOfService = () => <TermsOfServicePage />
+
+export default TermsOfService


### PR DESCRIPTION
## Summary
- add About page
- add Privacy Policy page
- add Terms of Service page
- link to new pages from login page
- localize new nav labels

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687a7f3b74348328a6af0a701cf4e436