### PR TITLE
Support multi-line paste for task items

### DIFF
--- a/app/components/base/milkdown-editor/index.tsx
+++ b/app/components/base/milkdown-editor/index.tsx
@@ -23,15 +23,7 @@ export const MilkdownEditor = <TFormValues extends Record<string, unknown>>(
       root,
       defaultValue: (getValues(name) as string) || '',
       features: {
-        // [Crepe.Feature.Cursor]: true,
-        // [Crepe.Feature.ListItem]: true,
-        // [Crepe.Feature.LinkTooltip]: true,
-        // [Crepe.Feature.ImageBlock]: true,
         [Crepe.Feature.BlockEdit]: false,
-        // [Crepe.Feature.Toolbar]: true,
-        // [Crepe.Feature.CodeMirror]: true,
-        // [Crepe.Feature.Table]: true,
-        // [Crepe.Feature.Latex]: true,
       },
       featureConfigs: {
         [Crepe.Feature.Placeholder]: {

--- a/app/components/base/textarea/index.tsx
+++ b/app/components/base/textarea/index.tsx
@@ -23,6 +23,7 @@ export const Textarea = <TFormValues extends Record<string, unknown>>(
     name,
     label,
     onClick,
+    onPaste,
     hint,
     className,
     containerClassName,
@@ -62,6 +63,7 @@ export const Textarea = <TFormValues extends Record<string, unknown>>(
                   inputClassName,
                 )}
                 onClick={onClick}
+                onPaste={onPaste}
                 onInput={(event) => {
                   const target = event.target as HTMLTextAreaElement
                   target.style.height = 'auto'

--- a/app/components/base/textarea/type.ts
+++ b/app/components/base/textarea/type.ts
@@ -4,6 +4,7 @@ import {
   MouseEventHandler,
   ReactNode,
   TextareaHTMLAttributes,
+  ClipboardEventHandler,
 } from 'react'
 import { FieldValues, Path } from 'react-hook-form'
 
@@ -29,4 +30,5 @@ export type TProperties<TFormValues extends FieldValues> = {
   autoResize?: boolean
   rows?: TextareaHTMLAttributes<HTMLTextAreaElement>['rows']
   onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>
+  onPaste?: ClipboardEventHandler<HTMLTextAreaElement>
 }

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -221,6 +221,34 @@ export const Form = (properties: TFormProperties) => {
     }
   }
 
+  const handleNewItemPaste = (
+    event: React.ClipboardEvent<HTMLTextAreaElement>,
+  ) => {
+    const text = event.clipboardData.getData('text')
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+    if (lines.length > 1) {
+      event.preventDefault()
+      setSelectedEdit(undefined)
+      const base = fieldsContent.length
+      let index = 0
+      for (const line of lines) {
+        append({
+          sequence: base + index,
+          checked: false,
+          item: line,
+        })
+        index += 1
+      }
+      setValue('item', '')
+      requestAnimationFrame(() => {
+        setFocus('item')
+      })
+    }
+  }
+
   return (
     <FormProvider {...formMethods}>
       <form
@@ -367,6 +395,7 @@ export const Form = (properties: TFormProperties) => {
           rows={1}
           readOnly={task && !isEditable}
           onKeyDown={handleNewItemKeyDown}
+          onPaste={handleNewItemPaste}
           leftNode={({ className }) => (
             <div
               className={cn(


### PR DESCRIPTION
## Summary
- allow `Textarea` to receive `onPaste`
- handle multi-line paste when adding new task items

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687c2e34b25483289ebda1a14099ad54