### PR TITLE
Render markdown in notes list previews

### DIFF
--- a/app/components/base/markdown/index.tsx
+++ b/app/components/base/markdown/index.tsx
@@ -1,0 +1,12 @@
+import MarkdownToJsx from 'markdown-to-jsx'
+
+import { TMarkdownProperties } from './type'
+
+export const Markdown = (properties: TMarkdownProperties) => {
+  const { children, className } = properties
+  return (
+    <div className={className}>
+      <MarkdownToJsx>{children}</MarkdownToJsx>
+    </div>
+  )
+}

--- a/app/components/base/markdown/type.ts
+++ b/app/components/base/markdown/type.ts
@@ -1,0 +1,6 @@
+import { HTMLAttributes } from 'react'
+
+export type TMarkdownProperties = {
+  children: string
+  className?: HTMLAttributes<HTMLDivElement>['className']
+}

--- a/app/components/pages/notes/card.tsx
+++ b/app/components/pages/notes/card.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { Action } from '~/components/base/action'
+import { Markdown } from '~/components/base/markdown'
 import {
   Card as UICard,
   CardContent,
@@ -73,9 +74,9 @@ export const Card = (properties: TCardProperties) => {
       </CardHeader>
       {note.content && (
         <CardContent>
-          <p className="whitespace-pre-wrap break-words text-sm">
+          <Markdown className="whitespace-pre-wrap break-words text-sm">
             {note.content}
-          </p>
+          </Markdown>
         </CardContent>
       )}
     </UICard>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "i18next-http-backend": "^3.0.1",
     "isbot": "^4.1.0",
     "lucide-react": "^0.464.0",
+    "markdown-to-jsx": "^7.7.12",
     "masonry-layout": "^4.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       lucide-react:
         specifier: ^0.464.0
         version: 0.464.0(react@18.3.1)
+      markdown-to-jsx:
+        specifier: ^7.7.12
+        version: 7.7.12(react@18.3.1)
       masonry-layout:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3663,6 +3666,12 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  markdown-to-jsx@7.7.12:
+    resolution: {integrity: sha512-Y5xNBqoaTooSLkmlg2P0fdbh53gp4MqW7zhvcweGCPUWvWI5BecWRYI8vPlzT8D7OULxsQg2qoRW9EsJlBWasQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      react: '>= 0.14.0'
 
   masonry-layout@4.2.2:
     resolution: {integrity: sha512-iGtAlrpHNyxaR19CvKC3npnEcAwszXoyJiI8ARV2ePi7fmYhIud25MHK8Zx4P0LCC4d3TNO9+rFa1KoK1OEOaA==}
@@ -9554,6 +9563,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   markdown-table@3.0.4: {}
+
+  markdown-to-jsx@7.7.12(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   masonry-layout@4.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- add Markdown renderer component using `markdown-to-jsx`
- show formatted markdown in note preview cards
- update dependencies

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_687e84aed4a8832890573a686c15acea