### PR TITLE
Make note/task actions float

### DIFF
--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -95,9 +95,10 @@ export const Form = (properties: TFormProperties) => {
         onSubmit={onSubmit}
         className="group/form is-shown mx-auto w-full max-w-6xl space-y-4"
       >
-        <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 justify-center md:static md:transform-none">
+        <div className="sticky top-24 z-50 flex justify-center">
           {note ? (
             <Action
+              className="w-full"
               isOwner={isOwner}
               isEditable={isEditable}
               isPinned={isPinned}
@@ -110,6 +111,7 @@ export const Form = (properties: TFormProperties) => {
             />
           ) : (
             <Action
+              className="w-full"
               isLoading={isCreatePending}
               isCreate={true}
               handleBack={() => handleBackNote()}

--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -95,26 +95,28 @@ export const Form = (properties: TFormProperties) => {
         onSubmit={onSubmit}
         className="group/form is-shown mx-auto w-full max-w-6xl space-y-4"
       >
-        {note ? (
-          <Action
-            isOwner={isOwner}
-            isEditable={isEditable}
-            isPinned={isPinned}
-            handleDelete={() => handleDeleteNote({ note })}
-            handlePin={() => handlePinNote({ note, isPinned: !isPinned })}
-            handleShare={() => handleShareNote({ note })}
-            handleUnlink={() => handleUnlinkNote({ note })}
-            sharedCount={sharedCount}
-            handleBack={() => handleBackNote()}
-          />
-        ) : (
-          <Action
-            isLoading={isCreatePending}
-            isCreate={true}
-            handleBack={() => handleBackNote()}
-            disabled={!isDirty}
-          />
-        )}
+        <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 justify-center md:static md:transform-none">
+          {note ? (
+            <Action
+              isOwner={isOwner}
+              isEditable={isEditable}
+              isPinned={isPinned}
+              handleDelete={() => handleDeleteNote({ note })}
+              handlePin={() => handlePinNote({ note, isPinned: !isPinned })}
+              handleShare={() => handleShareNote({ note })}
+              handleUnlink={() => handleUnlinkNote({ note })}
+              sharedCount={sharedCount}
+              handleBack={() => handleBackNote()}
+            />
+          ) : (
+            <Action
+              isLoading={isCreatePending}
+              isCreate={true}
+              handleBack={() => handleBackNote()}
+              disabled={!isDirty}
+            />
+          )}
+        </div>
         <Textarea
           name="title"
           placeholder={t('notes.form.title.label')}

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -264,9 +264,10 @@ export const Form = (properties: TFormProperties) => {
         onSubmit={onSubmit}
         className="group/form is-shown mx-auto w-full max-w-6xl space-y-4"
       >
-        <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 justify-center md:static md:transform-none">
+        <div className="sticky top-24 z-50 flex justify-center">
           {task ? (
             <Action
+              className="w-full"
               isOwner={isOwner}
               isEditable={isEditable}
               isPinned={isPinned}
@@ -279,6 +280,7 @@ export const Form = (properties: TFormProperties) => {
             />
           ) : (
             <Action
+              className="w-full"
               isLoading={isCreatePending}
               isCreate={true}
               handleBack={() => handleBackTask()}

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -264,26 +264,28 @@ export const Form = (properties: TFormProperties) => {
         onSubmit={onSubmit}
         className="group/form is-shown mx-auto w-full max-w-6xl space-y-4"
       >
-        {task ? (
-          <Action
-            isOwner={isOwner}
-            isEditable={isEditable}
-            isPinned={isPinned}
-            handleDelete={() => handleDeleteTask({ task })}
-            handlePin={() => handlePinTask({ task, isPinned: !isPinned })}
-            handleShare={() => handleShareTask({ task })}
-            handleUnlink={() => handleUnlinkTask({ task })}
-            sharedCount={sharedCount}
-            handleBack={() => handleBackTask()}
-          />
-        ) : (
-          <Action
-            isLoading={isCreatePending}
-            isCreate={true}
-            handleBack={() => handleBackTask()}
-            disabled={!isDirty}
-          />
-        )}
+        <div className="fixed bottom-4 left-1/2 z-50 flex -translate-x-1/2 justify-center md:static md:transform-none">
+          {task ? (
+            <Action
+              isOwner={isOwner}
+              isEditable={isEditable}
+              isPinned={isPinned}
+              handleDelete={() => handleDeleteTask({ task })}
+              handlePin={() => handlePinTask({ task, isPinned: !isPinned })}
+              handleShare={() => handleShareTask({ task })}
+              handleUnlink={() => handleUnlinkTask({ task })}
+              sharedCount={sharedCount}
+              handleBack={() => handleBackTask()}
+            />
+          ) : (
+            <Action
+              isLoading={isCreatePending}
+              isCreate={true}
+              handleBack={() => handleBackTask()}
+              disabled={!isDirty}
+            />
+          )}
+        </div>
         <Textarea
           name="title"
           placeholder={t('tasks.form.title.label')}


### PR DESCRIPTION
## Summary
- float action buttons for notes
- float action buttons for tasks

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687ed7c725448328ac4078c0da019a15