### PR TITLE
Fix note editor focus

### DIFF
--- a/app/components/base/milkdown-editor/index.tsx
+++ b/app/components/base/milkdown-editor/index.tsx
@@ -1,6 +1,6 @@
 import { Crepe } from '@milkdown/crepe'
-import { Milkdown, useEditor } from '@milkdown/react'
-import { useEffect } from 'react'
+import { Milkdown, useEditor, useInstance } from '@milkdown/react'
+import { useCallback } from 'react'
 import { PathValue, useFormContext } from 'react-hook-form'
 
 import { TMilkdownEditorProperties } from './type'
@@ -13,10 +13,8 @@ export const MilkdownEditor = <TFormValues extends Record<string, unknown>>(
 ) => {
   const { name, placeholder: placeholderText } = properties
   const { register, setValue, getValues } = useFormContext<TFormValues>()
-
-  useEffect(() => {
-    register(name)
-  }, [register, name])
+  const { ref } = register(name)
+  const [, getEditor] = useInstance()
 
   useEditor((root) =>
     new Crepe({
@@ -40,5 +38,30 @@ export const MilkdownEditor = <TFormValues extends Record<string, unknown>>(
     }),
   )
 
-  return <Milkdown />
+  const handleReference = useCallback(
+    (element: HTMLTextAreaElement | null) => {
+      ref(element)
+    },
+    [ref],
+  )
+
+  const handleFocus = () => {
+    const instance = getEditor() as unknown as { view?: { focus: () => void; hasFocus: () => boolean } }
+    if (instance?.view && !instance.view.hasFocus()) {
+      instance.view.focus()
+    }
+  }
+
+  return (
+    <>
+      <textarea
+        ref={handleReference}
+        tabIndex={-1}
+        aria-hidden
+        className="sr-only"
+        onFocus={handleFocus}
+      />
+      <Milkdown />
+    </>
+  )
 }

--- a/app/components/base/milkdown-editor/index.tsx
+++ b/app/components/base/milkdown-editor/index.tsx
@@ -1,4 +1,5 @@
 import { Crepe } from '@milkdown/crepe'
+import { editorViewCtx } from '@milkdown/kit/core'
 import { Milkdown, useEditor, useInstance } from '@milkdown/react'
 import { useCallback } from 'react'
 import { PathValue, useFormContext } from 'react-hook-form'
@@ -46,9 +47,12 @@ export const MilkdownEditor = <TFormValues extends Record<string, unknown>>(
   )
 
   const handleFocus = () => {
-    const instance = getEditor() as unknown as { view?: { focus: () => void; hasFocus: () => boolean } }
-    if (instance?.view && !instance.view.hasFocus()) {
-      instance.view.focus()
+    const instance = getEditor()
+    if (instance?.action) {
+      instance.action((context) => {
+        const view = context.get(editorViewCtx)
+        view.focus()
+      })
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
     "@milkdown/crepe": "^7.15.1",
+    "@milkdown/kit": "^7.15.1",
     "@milkdown/react": "^7.15.1",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@milkdown/crepe':
         specifier: ^7.15.1
         version: 7.15.1(prosemirror-model@1.25.2)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)(typescript@5.8.3)
+      '@milkdown/kit':
+        specifier: ^7.15.1
+        version: 7.15.1(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(typescript@5.8.3)
       '@milkdown/react':
         specifier: ^7.15.1
         version: 7.15.1(@codemirror/language@6.11.2)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)(prosemirror-model@1.25.2)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)


### PR DESCRIPTION
## Summary
- allow focusing Milkdown editor when using `setFocus('content')`

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687ee1324c4883289e709d432d293409