### PR TITLE
Implement focus behavior in note editor

### DIFF
--- a/app/components/base/milkdown-editor/type.ts
+++ b/app/components/base/milkdown-editor/type.ts
@@ -3,4 +3,5 @@ import { FieldValues, Path } from 'react-hook-form'
 export type TMilkdownEditorProperties<TFormValues extends FieldValues> = {
   name: Path<TFormValues>
   placeholder?: string
+  previousName?: Path<TFormValues>
 }

--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -67,6 +67,7 @@ export const Form = (properties: TFormProperties) => {
     setFocus,
   } = formMethods
   const watchTitle = watch('title')
+  const watchContent = watch('content')
 
   const onSubmit = handleSubmit(async (data) => {
     if ((data.title.length === 0 && data.content.length === 0) || !isDirty) {
@@ -84,7 +85,7 @@ export const Form = (properties: TFormProperties) => {
 
   useDebounce({
     trigger: () => onSubmit(),
-    watch: [watchTitle],
+    watch: [watchTitle, watchContent],
     condition: !!selectedNote,
   })
 

--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -67,7 +67,6 @@ export const Form = (properties: TFormProperties) => {
     setFocus,
   } = formMethods
   const watchTitle = watch('title')
-  const watchContent = watch('content')
 
   const onSubmit = handleSubmit(async (data) => {
     if ((data.title.length === 0 && data.content.length === 0) || !isDirty) {
@@ -85,7 +84,7 @@ export const Form = (properties: TFormProperties) => {
 
   useDebounce({
     trigger: () => onSubmit(),
-    watch: [watchTitle, watchContent],
+    watch: [watchTitle],
     condition: !!selectedNote,
   })
 
@@ -137,6 +136,7 @@ export const Form = (properties: TFormProperties) => {
           key={selectedNote?.id ?? 'create'}
           name="content"
           placeholder={t('notes.form.content.label')}
+          previousName="title"
         />
       </form>
       <span className="flex justify-center text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- add `previousName` prop to `MilkdownEditor`
- use Crepe listener to move focus when pressing backspace on empty content or arrow up from first line
- wire note form to use new prop

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_687f228b01b8832883ed6ef089ff8bef