### PR TITLE
Fix arrow up detection for milkdown

### DIFF
--- a/app/components/base/milkdown-editor/index.tsx
+++ b/app/components/base/milkdown-editor/index.tsx
@@ -48,11 +48,13 @@ export const MilkdownEditor = <TFormValues extends Record<string, unknown>>(
             const isBackspace = event.key === 'Backspace'
             const isArrowUp = event.key === 'ArrowUp'
             const isEmpty = view.state.doc.textContent.length === 0
-            const atStart = view.state.selection.from === 1
+            const atFirstLine = !view.state.doc
+              .textBetween(0, view.state.selection.from)
+              .includes('\n')
             if (isBackspace && isEmpty) {
               event.preventDefault()
               setFocus(previousName)
-            } else if (isArrowUp && atStart) {
+            } else if (isArrowUp && atFirstLine) {
               event.preventDefault()
               setFocus(previousName)
             }


### PR DESCRIPTION
## Summary
- refine at-first-line detection in Milkdown editor's keydown handler

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_687f447b75708328ab7828379b0a5c42