### PR TITLE
Add size preference setting

### DIFF
--- a/app/apis/firestore/user.ts
+++ b/app/apis/firestore/user.ts
@@ -177,7 +177,7 @@ export const loginWithGoogle = async () => {
 }
 
 export const register = async (userData: TSignUpRequest) => {
-  const { email, password, displayName, language, theme } = userData
+  const { email, password, displayName, language, theme, size } = userData
   if (!auth || !firestore) {
     throw new Error('Firebase is not initialized.')
   }
@@ -204,6 +204,7 @@ export const register = async (userData: TSignUpRequest) => {
       email,
       language,
       theme,
+      size,
       createdAt: new Date(),
     })
   } else {

--- a/app/components/base/size-toggle/constant.ts
+++ b/app/components/base/size-toggle/constant.ts
@@ -1,0 +1,16 @@
+import { TFunction } from 'i18next'
+
+export const sizeOptions = (t: TFunction) => [
+  {
+    value: 'small',
+    label: t('settings.appearance.form.size.small'),
+  },
+  {
+    value: 'medium',
+    label: t('settings.appearance.form.size.medium'),
+  },
+  {
+    value: 'large',
+    label: t('settings.appearance.form.size.large'),
+  },
+]

--- a/app/components/base/size-toggle/index.tsx
+++ b/app/components/base/size-toggle/index.tsx
@@ -1,0 +1,121 @@
+import { Slot } from '@radix-ui/react-slot'
+import { Type } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '~/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { Label } from '~/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group'
+import { Size, useTheme } from '~/lib/contexts/theme'
+
+import { sizeOptions } from './constant'
+import { TParameters, TProperties } from './type'
+
+export const SizeToggle = (properties: TProperties) => {
+  const { type = 'dropdown', onChange, value } = properties
+  const { setSize, size } = useTheme()
+  const currentSize = value ?? size
+
+  const handleSetSize = (newValue: Size) => {
+    if (value === undefined) {
+      setSize(newValue)
+    }
+    onChange?.(newValue)
+  }
+
+  if (type === 'radio') {
+    return (
+      <Radio
+        value={currentSize}
+        handleSetSize={handleSetSize}
+      />
+    )
+  }
+
+  return (
+    <Dropdown
+      value={currentSize}
+      handleSetSize={handleSetSize}
+    />
+  )
+}
+
+const Radio = (parameters: TParameters) => {
+  const { value, handleSetSize } = parameters
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-1">
+      <Label>{t('settings.appearance.form.size.selector')}</Label>
+      <Slot>
+        <RadioGroup
+          onValueChange={handleSetSize}
+          value={value}
+          className="flex flex-col"
+        >
+          {sizeOptions(t).map((option) => (
+            <div
+              key={option.value}
+              className="flex items-center space-x-3 space-y-0"
+            >
+              <Slot>
+                <RadioGroupItem
+                  value={option.value}
+                  id={option.value}
+                />
+              </Slot>
+              <Label
+                className="font-normal text-muted-foreground"
+                htmlFor={option.value}
+              >
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </Slot>
+    </div>
+  )
+}
+
+const Dropdown = (parameters: TParameters) => {
+  const { value, handleSetSize } = parameters
+  const { t } = useTranslation()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+        >
+          <Type className="h-[1.2rem] w-[1.2rem]" />
+          <span className="sr-only">
+            {t('settings.appearance.form.size.selector')}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={(newValue) => handleSetSize(newValue as Size)}
+        >
+          {sizeOptions(t).map((option) => (
+            <DropdownMenuRadioItem
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/components/base/size-toggle/type.ts
+++ b/app/components/base/size-toggle/type.ts
@@ -1,0 +1,12 @@
+import { Size } from '~/lib/contexts/theme'
+
+export type TProperties = {
+  type?: 'dropdown' | 'radio'
+  value?: Size
+  onChange?: (value: Size) => void
+}
+
+export type TParameters = {
+  value: Size
+  handleSetSize: (value: Size) => void
+}

--- a/app/components/pages/general-settings/appearance.tsx
+++ b/app/components/pages/general-settings/appearance.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { Button } from '~/components/base/button'
 import { LanguageSelector } from '~/components/base/language-selector'
 import { ModeToggle } from '~/components/base/mode-toggle'
+import { SizeToggle } from '~/components/base/size-toggle'
 import {
   Card,
   CardContent,
@@ -22,7 +23,7 @@ import { supportedLanguages } from '~/localization/resource'
 
 export const Appearance = () => {
   const { t, i18n } = useTranslation()
-  const { theme } = useTheme()
+  const { theme, size } = useTheme()
   const { mutate, isPending } = useUpdateAppearance()
   const { data: userData } = useUserData()
 
@@ -30,12 +31,14 @@ export const Appearance = () => {
     values: {
       theme: userData?.theme ?? theme,
       language: userData?.language ?? supportedLanguages[0],
+      size: userData?.size ?? size,
     },
   })
   const { handleSubmit, watch, formState } = formMethods
 
   const watchTheme = watch('theme')
   const watchLanguage = watch('language')
+  const watchSize = watch('size')
 
   useEffect(() => {
     const root = document.documentElement
@@ -51,6 +54,14 @@ export const Appearance = () => {
       root.classList.add(value)
     }
   }, [watchTheme])
+
+  useEffect(() => {
+    const root = document.documentElement
+    let value = '100%'
+    if (watchSize === 'small') value = '87.5%'
+    else if (watchSize === 'large') value = '112.5%'
+    root.style.setProperty('--base-size', value)
+  }, [watchSize])
 
   useEffect(() => {
     if (watchLanguage && i18n.language !== watchLanguage)
@@ -92,6 +103,17 @@ export const Appearance = () => {
               name="theme"
               render={({ field }) => (
                 <ModeToggle
+                  type="radio"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+            <Controller
+              control={formMethods.control}
+              name="size"
+              render={({ field }) => (
+                <SizeToggle
                   type="radio"
                   value={field.value}
                   onChange={field.onChange}

--- a/app/components/pages/sign-in/index.tsx
+++ b/app/components/pages/sign-in/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '~/components/base/button'
 import { Input } from '~/components/base/input'
 import { LanguageSelector } from '~/components/base/language-selector'
 import { ModeToggle } from '~/components/base/mode-toggle'
+import { SizeToggle } from '~/components/base/size-toggle'
 import { Button as UIButton } from '~/components/ui/button'
 import {
   CardContent,
@@ -87,6 +88,7 @@ export const SignInPage = () => {
           <div className="flex space-x-2">
             <LanguageSelector />
             <ModeToggle />
+            <SizeToggle />
           </div>
         </div>
       </CardHeader>

--- a/app/components/pages/sign-up/index.tsx
+++ b/app/components/pages/sign-up/index.tsx
@@ -9,6 +9,7 @@ import { Button } from '~/components/base/button'
 import { Input } from '~/components/base/input'
 import { LanguageSelector } from '~/components/base/language-selector'
 import { ModeToggle } from '~/components/base/mode-toggle'
+import { SizeToggle } from '~/components/base/size-toggle'
 import { Button as UIButton } from '~/components/ui/button'
 import {
   CardContent,
@@ -27,7 +28,7 @@ export const SignUpPage = () => {
   const { t, i18n } = useTranslation(['common', 'zod'])
   const [disabled, setDisabled] = useState(false)
   const [passwordType, setPasswordType] = useState('password')
-  const { theme } = useTheme()
+  const { theme, size } = useTheme()
   const formMethods = useForm<TSignUpRequest>({
     resolver: zodResolver(signUpSchema(t)),
     defaultValues: {
@@ -40,7 +41,7 @@ export const SignUpPage = () => {
   const { handleSubmit } = formMethods
   const onSubmit = handleSubmit(async (data) => {
     setDisabled(true)
-    mutateRegister({ ...data, theme, language: i18n.language })
+    mutateRegister({ ...data, theme, language: i18n.language, size })
   })
   const togglePassword = () => {
     setPasswordType((previous) =>
@@ -71,6 +72,7 @@ export const SignUpPage = () => {
           <div className="flex space-x-2">
             <LanguageSelector />
             <ModeToggle />
+            <SizeToggle />
           </div>
         </div>
       </CardHeader>

--- a/app/lib/contexts/theme.tsx
+++ b/app/lib/contexts/theme.tsx
@@ -7,21 +7,28 @@ import {
 } from 'react'
 
 export type Theme = 'system' | 'light' | 'dark'
+export type Size = 'small' | 'medium' | 'large'
 
 type ThemeProviderProperties = {
   children: ReactNode
   defaultTheme?: Theme
-  storageKey?: string
+  defaultSize?: Size
+  themeStorageKey?: string
+  sizeStorageKey?: string
 }
 
 type ThemeProviderState = {
   theme: Theme
+  size: Size
   setTheme: (theme: Theme) => void
+  setSize: (size: Size) => void
 }
 
 const initialState: ThemeProviderState = {
   theme: 'system',
+  size: 'medium',
   setTheme: () => null,
+  setSize: () => null,
 }
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
@@ -29,11 +36,16 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 export const ThemeProvider = ({
   children,
   defaultTheme = 'system',
-  storageKey = 'vite-ui-theme',
+  defaultSize = 'medium',
+  themeStorageKey = 'vite-ui-theme',
+  sizeStorageKey = 'tailwind-size',
   ...properties
 }: ThemeProviderProperties) => {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+  const [theme, setThemeState] = useState<Theme>(
+    () => (localStorage.getItem(themeStorageKey) as Theme) || defaultTheme,
+  )
+  const [size, setSizeState] = useState<Size>(
+    () => (localStorage.getItem(sizeStorageKey) as Size) || defaultSize,
   )
 
   useEffect(() => {
@@ -52,12 +64,30 @@ export const ThemeProvider = ({
     root.classList.add(theme)
   }, [theme])
 
+  useEffect(() => {
+    const root = globalThis.document.documentElement
+    let value = '100%'
+    if (size === 'small') value = '87.5%'
+    else if (size === 'large') value = '112.5%'
+    root.style.setProperty('--base-size', value)
+    root.dataset.size = size
+  }, [size])
+
+  const setTheme = (newTheme: Theme) => {
+    localStorage.setItem(themeStorageKey, newTheme)
+    setThemeState(newTheme)
+  }
+
+  const setSize = (newSize: Size) => {
+    localStorage.setItem(sizeStorageKey, newSize)
+    setSizeState(newSize)
+  }
+
   const value = {
     theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme)
-      setTheme(theme)
-    },
+    size,
+    setTheme,
+    setSize,
   }
 
   return (

--- a/app/lib/types/settings.ts
+++ b/app/lib/types/settings.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { Theme } from '~/lib/contexts/theme'
+import { Theme, Size } from '~/lib/contexts/theme'
 import { generalSettingSchema } from '~/lib/validations/settings'
 
 export type TUpdateProfileRequest = z.infer<typeof generalSettingSchema>
@@ -8,4 +8,5 @@ export type TUpdateProfileRequest = z.infer<typeof generalSettingSchema>
 export type TUpdateAppearanceRequest = {
   theme: Theme
   language: string
+  size: Size
 }

--- a/app/lib/types/user.ts
+++ b/app/lib/types/user.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { Theme } from '~/lib/contexts/theme'
+import { Theme, Size } from '~/lib/contexts/theme'
 import { TTime } from '~/lib/types/common'
 import { emailSchema, signInSchema, signUpSchema } from '~/lib/validations/user'
 
@@ -9,6 +9,7 @@ export type TSignInRequest = z.infer<ReturnType<typeof signInSchema>>
 export type TSignUpRequest = z.infer<ReturnType<typeof signUpSchema>> & {
   theme: Theme
   language: string
+  size: Size
 }
 
 export type TEmailRequest = z.infer<ReturnType<typeof emailSchema>>
@@ -24,4 +25,5 @@ export type TUserResponse = {
   numberFormat?: string
   language?: string
   theme?: Theme
+  size?: Size
 }

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -286,6 +286,12 @@
           "dark": "Dark",
           "light": "Light",
           "system": "System"
+        },
+        "size": {
+          "selector": "Size",
+          "small": "Small",
+          "medium": "Medium",
+          "large": "Large"
         }
       },
       "toast": {

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -286,6 +286,12 @@
           "dark": "Gelap",
           "light": "Terang",
           "system": "Sistem"
+        },
+        "size": {
+          "selector": "Ukuran",
+          "small": "Kecil",
+          "medium": "Sedang",
+          "large": "Besar"
         }
       },
       "toast": {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,7 +29,7 @@ export { meta, links } from '~/lib/constants/metadata'
 
 export const HydrateFallback = () => {
   const { i18n } = useTranslation()
-  const { theme } = useTheme()
+  const { theme, size } = useTheme()
   useEffect(() => {
     const root = globalThis.document.documentElement
     root.classList.remove('light', 'dark')
@@ -45,6 +45,14 @@ export const HydrateFallback = () => {
 
     root.classList.add(theme)
   }, [theme])
+
+  useEffect(() => {
+    const root = globalThis.document.documentElement
+    let value = '100%'
+    if (size === 'small') value = '87.5%'
+    else if (size === 'large') value = '112.5%'
+    root.style.setProperty('--base-size', value)
+  }, [size])
 
   return (
     <html

--- a/app/routes/_layout._main.tsx
+++ b/app/routes/_layout._main.tsx
@@ -17,14 +17,15 @@ export const clientLoader = async () => {
 
 const Main = () => {
   const { data: userData } = useUserData()
-  const { setTheme, theme } = useTheme()
+  const { setTheme, setSize, theme, size } = useTheme()
   const { i18n } = useTranslation()
 
   useEffect(() => {
     if (userData?.theme && theme !== userData.theme) setTheme(userData.theme)
     if (userData?.language && i18n.language !== userData.language)
       i18n.changeLanguage(userData.language)
-  }, [userData, setTheme, i18n, theme])
+    if (userData?.size && size !== userData.size) setSize(userData.size)
+  }, [userData, setTheme, i18n, theme, setSize, size])
 
   return (
     <main className="flex min-h-dvh w-full flex-col">

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -4,6 +4,7 @@
 
 html {
   scroll-behavior: smooth;
+  font-size: var(--base-size);
 }
 
 html,
@@ -67,6 +68,7 @@ body {
     --input: 20 5.9% 90%;
     --ring: 20 14.3% 4.1%;
     --radius: 1rem;
+    --base-size: 100%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -94,6 +96,7 @@ body {
     --border: 12 6.5% 15.1%;
     --input: 12 6.5% 15.1%;
     --ring: 35.5 91.7% 32.9%;
+    --base-size: 100%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;


### PR DESCRIPTION
## Summary
- add Size context and provider
- implement SizeToggle component
- update settings appearance and auth pages to support tailwind size options
- store size in user profile and update APIs
- sync size preference on initial load

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_687fb2dc7aa083288de13cbf2e0147ae