### PR TITLE
Fix task deletion toast

### DIFF
--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -10,10 +10,12 @@ import { Checkbox } from '~/components/base/checkbox'
 import { Textarea } from '~/components/base/textarea'
 import { useTask } from '~/components/pages/tasks'
 import { Button } from '~/components/ui/button'
+import { ToastAction } from '~/components/ui/toast'
 import { auth } from '~/lib/configs/firebase'
 import { useCreateTask } from '~/lib/hooks/use-create-task'
 import { useDebounce } from '~/lib/hooks/use-debounce'
 import { useUserData } from '~/lib/hooks/use-get-user'
+import { toast } from '~/lib/hooks/use-toast'
 import { useUpdateTask } from '~/lib/hooks/use-update-task'
 import { TTaskForm } from '~/lib/types/task'
 import { getDateLabel } from '~/lib/utils/parser'
@@ -80,6 +82,7 @@ export const Form = (properties: TFormProperties) => {
     remove,
     update,
     move,
+    insert,
   } = useFieldArray({
     control: control,
     name: 'content',
@@ -101,6 +104,22 @@ export const Form = (properties: TFormProperties) => {
         checked: newValue,
       })
     }
+  }
+
+  const handleRemoveItem = (index: number) => {
+    const item = watchContent[index]
+    remove(index)
+    toast({
+      description: t('tasks.toast.itemDeleted', { item: item.item }),
+      action: (
+        <ToastAction
+          altText="Undo"
+          onClick={() => insert(index, item)}
+        >
+          {t('form.undo')}
+        </ToastAction>
+      ),
+    })
   }
 
   const onSubmit = handleSubmit(async (data) => {
@@ -177,7 +196,7 @@ export const Form = (properties: TFormProperties) => {
       setSelectedEdit(undefined)
       const isRemoving = item.length === 0
       if (isRemoving) {
-        remove(index)
+        handleRemoveItem(index)
       } else {
         update(index, {
           ...field,
@@ -188,7 +207,7 @@ export const Form = (properties: TFormProperties) => {
     }
     if (isBackspace && item.length === 0) {
       event.preventDefault()
-      remove(index)
+      handleRemoveItem(index)
       focusPreviousUnchecked(index)
     }
     if (isArrowUp) {
@@ -390,7 +409,7 @@ export const Form = (properties: TFormProperties) => {
                             selectedEdit === index ? 'hidden' : '',
                           )}
                           type="button"
-                          onClick={() => remove(index)}
+                          onClick={() => handleRemoveItem(index)}
                         >
                           <Trash />
                         </Button>

--- a/app/lib/hooks/use-delete-task.tsx
+++ b/app/lib/hooks/use-delete-task.tsx
@@ -19,7 +19,7 @@ export const useDeleteTask = () => {
       const { isPinned: _isPinned, id: _id, ...data } = task
       await deleteTask(task)
       toast({
-        description: t('notes.toast.deleted'),
+        description: t('tasks.toast.deleted'),
         action: (
           <ToastAction
             altText="Undo"

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -140,7 +140,8 @@
       "deleted": "Task deleted successfully",
       "created": "Task created successfully",
       "unlinked": "Task unlinked successfully",
-      "notFound": "Task not found or you don't have access"
+      "notFound": "Task not found or you don't have access",
+      "itemDeleted": "{{item}} removed"
     }
   },
   "finances": {

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -140,7 +140,8 @@
       "deleted": "Tugas berhasil dihapus",
       "created": "Tugas berhasil dibuat",
       "unlinked": "Tugas berhasil diputuskan",
-      "notFound": "Tugas tidak ditemukan atau Anda tidak memiliki akses"
+      "notFound": "Tugas tidak ditemukan atau Anda tidak memiliki akses",
+      "itemDeleted": "{{item}} dihapus"
     }
   },
   "finances": {


### PR DESCRIPTION
## Summary
- fix toast translation for task deletion so it shows task-specific messages with Undo action
- show undo toast when deleting a checklist item in Task form

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_68800b0c311083289dc7601f6291aeb5