### PR TITLE
Add realtime fetch by id for notes and tasks

### DIFF
--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -19,7 +19,7 @@ import { noteSchema } from '~/lib/validations/note'
 import { TFormProperties } from './type'
 
 export const Form = (properties: TFormProperties) => {
-  const { notes } = properties
+  const { note } = properties
   const { t, i18n } = useTranslation()
   const {
     selectedNote,
@@ -29,7 +29,6 @@ export const Form = (properties: TFormProperties) => {
     handleUnlinkNote,
     handleBackNote,
   } = useNote()
-  const note = notes?.find((n) => n.id === selectedNote?.id)
   const dateLabel = note
     ? getDateLabel({
         updatedAt: note.updatedAt?.seconds,

--- a/app/components/pages/note-detail/type.ts
+++ b/app/components/pages/note-detail/type.ts
@@ -1,5 +1,5 @@
 import { TNoteResponse } from '~/lib/types/note'
 
 export type TFormProperties = {
-  notes?: TNoteResponse[]
+  note?: TNoteResponse
 }

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -25,7 +25,7 @@ import { taskSchema } from '~/lib/validations/task'
 import { TFormProperties } from './type'
 
 export const Form = (properties: TFormProperties) => {
-  const { tasks } = properties
+  const { task } = properties
   const { t, i18n } = useTranslation()
   const {
     selectedTask,
@@ -35,7 +35,6 @@ export const Form = (properties: TFormProperties) => {
     handleUnlinkTask,
     handleBackTask,
   } = useTask()
-  const task = tasks?.find((n) => n.id === selectedTask?.id)
   const dateLabel = task
     ? getDateLabel({
         updatedAt: task.updatedAt?.seconds,

--- a/app/components/pages/task-detail/type.ts
+++ b/app/components/pages/task-detail/type.ts
@@ -1,5 +1,5 @@
 import { TTaskResponse } from '~/lib/types/task'
 
 export type TFormProperties = {
-  tasks?: TTaskResponse[]
+  task?: TTaskResponse
 }

--- a/app/lib/hooks/use-get-note.ts
+++ b/app/lib/hooks/use-get-note.ts
@@ -1,0 +1,48 @@
+import { doc, onSnapshot } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
+
+import { auth, firestore } from '~/lib/configs/firebase'
+import { TNoteResponse } from '~/lib/types/note'
+import { waitForAuth } from '~/lib/utils/wait-for-auth'
+
+export const useGetNote = (id?: string) => {
+  const [data, setData] = useState<TNoteResponse>()
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (!firestore || !id) return
+    const database = firestore
+    let unsubscribe: () => void
+
+    const listen = async () => {
+      const user = auth?.currentUser ?? (await waitForAuth())
+      if (!user) {
+        setData(undefined)
+        setIsLoading(false)
+        return
+      }
+      const reference = doc(database, 'notes', id)
+      unsubscribe = onSnapshot(reference, (snap) => {
+        if (snap.exists()) {
+          const noteData = snap.data()
+          setData({
+            ...noteData,
+            id: snap.id,
+            isPinned: noteData.pinnedBy?.includes(user.uid),
+          } as TNoteResponse)
+        } else {
+          setData(undefined)
+        }
+        setIsLoading(false)
+      })
+    }
+
+    void listen()
+
+    return () => {
+      if (unsubscribe) unsubscribe()
+    }
+  }, [id])
+
+  return { data, isLoading }
+}

--- a/app/lib/hooks/use-get-task.ts
+++ b/app/lib/hooks/use-get-task.ts
@@ -1,0 +1,48 @@
+import { doc, onSnapshot } from 'firebase/firestore'
+import { useEffect, useState } from 'react'
+
+import { auth, firestore } from '~/lib/configs/firebase'
+import { TTaskResponse } from '~/lib/types/task'
+import { waitForAuth } from '~/lib/utils/wait-for-auth'
+
+export const useGetTask = (id?: string) => {
+  const [data, setData] = useState<TTaskResponse>()
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (!firestore || !id) return
+    const database = firestore
+    let unsubscribe: () => void
+
+    const listen = async () => {
+      const user = auth?.currentUser ?? (await waitForAuth())
+      if (!user) {
+        setData(undefined)
+        setIsLoading(false)
+        return
+      }
+      const reference = doc(database, 'tasks', id)
+      unsubscribe = onSnapshot(reference, (snap) => {
+        if (snap.exists()) {
+          const taskData = snap.data()
+          setData({
+            ...taskData,
+            id: snap.id,
+            isPinned: taskData.pinnedBy?.includes(user.uid),
+          } as TTaskResponse)
+        } else {
+          setData(undefined)
+        }
+        setIsLoading(false)
+      })
+    }
+
+    void listen()
+
+    return () => {
+      if (unsubscribe) unsubscribe()
+    }
+  }, [id])
+
+  return { data, isLoading }
+}


### PR DESCRIPTION
## Summary
- add hooks for realtime get note and task by id
- update note and task detail pages to use realtime single-item hooks
- adjust forms and types for single note/task inputs

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_68825b20a9c48328b3091c88ec1643b4