### PR TITLE
Fix loading spinner when creating notes/tasks

### DIFF
--- a/app/lib/hooks/use-get-note.ts
+++ b/app/lib/hooks/use-get-note.ts
@@ -10,7 +10,12 @@ export const useGetNote = (id?: string) => {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    if (!firestore || !id) return
+    if (!firestore || !id) {
+      setData(undefined)
+      setIsLoading(false)
+      return
+    }
+    setIsLoading(true)
     const database = firestore
     let unsubscribe: () => void
 

--- a/app/lib/hooks/use-get-task.ts
+++ b/app/lib/hooks/use-get-task.ts
@@ -10,7 +10,12 @@ export const useGetTask = (id?: string) => {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    if (!firestore || !id) return
+    if (!firestore || !id) {
+      setData(undefined)
+      setIsLoading(false)
+      return
+    }
+    setIsLoading(true)
     const database = firestore
     let unsubscribe: () => void
 


### PR DESCRIPTION
## Summary
- ensure `useGetNote` and `useGetTask` stop loading when no id is passed

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_68826248aad483288c7c14450a9dd3e8