### PR TITLE
Fix loading spinner when note or task not found

### DIFF
--- a/app/lib/hooks/use-get-note.ts
+++ b/app/lib/hooks/use-get-note.ts
@@ -27,19 +27,26 @@ export const useGetNote = (id?: string) => {
         return
       }
       const reference = doc(database, 'notes', id)
-      unsubscribe = onSnapshot(reference, (snap) => {
-        if (snap.exists()) {
-          const noteData = snap.data()
-          setData({
-            ...noteData,
-            id: snap.id,
-            isPinned: noteData.pinnedBy?.includes(user.uid),
-          } as TNoteResponse)
-        } else {
+      unsubscribe = onSnapshot(
+        reference,
+        (snap) => {
+          if (snap.exists()) {
+            const noteData = snap.data()
+            setData({
+              ...noteData,
+              id: snap.id,
+              isPinned: noteData.pinnedBy?.includes(user.uid),
+            } as TNoteResponse)
+          } else {
+            setData(undefined)
+          }
+          setIsLoading(false)
+        },
+        () => {
           setData(undefined)
-        }
-        setIsLoading(false)
-      })
+          setIsLoading(false)
+        },
+      )
     }
 
     void listen()

--- a/app/lib/hooks/use-get-task.ts
+++ b/app/lib/hooks/use-get-task.ts
@@ -27,19 +27,26 @@ export const useGetTask = (id?: string) => {
         return
       }
       const reference = doc(database, 'tasks', id)
-      unsubscribe = onSnapshot(reference, (snap) => {
-        if (snap.exists()) {
-          const taskData = snap.data()
-          setData({
-            ...taskData,
-            id: snap.id,
-            isPinned: taskData.pinnedBy?.includes(user.uid),
-          } as TTaskResponse)
-        } else {
+      unsubscribe = onSnapshot(
+        reference,
+        (snap) => {
+          if (snap.exists()) {
+            const taskData = snap.data()
+            setData({
+              ...taskData,
+              id: snap.id,
+              isPinned: taskData.pinnedBy?.includes(user.uid),
+            } as TTaskResponse)
+          } else {
+            setData(undefined)
+          }
+          setIsLoading(false)
+        },
+        () => {
           setData(undefined)
-        }
-        setIsLoading(false)
-      })
+          setIsLoading(false)
+        },
+      )
     }
 
     void listen()


### PR DESCRIPTION
## Summary
- handle snapshot errors in `useGetTask` and `useGetNote`

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_6882675081688328a408680f19582d04