### PR TITLE
Fix not-found redirect after create

### DIFF
--- a/app/components/pages/note-detail/content.tsx
+++ b/app/components/pages/note-detail/content.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router'
 
@@ -44,8 +44,14 @@ export const Content = () => {
     if (noteData) setSelectedNote(noteData)
   }, [noteData, setSelectedNote])
 
+  const previousLoading = useRef(noteIsLoading)
+
   useEffect(() => {
-    if (noteIsLoading || note === 'create' || noteData) {
+    const hasFinishedLoading = previousLoading.current && !noteIsLoading
+    previousLoading.current = noteIsLoading
+    if (!hasFinishedLoading) return
+
+    if (note === 'create' || noteData) {
       return
     }
 

--- a/app/components/pages/task-detail/content.tsx
+++ b/app/components/pages/task-detail/content.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router'
 
@@ -44,8 +44,14 @@ export const Content = () => {
     if (taskData) setSelectedTask(taskData)
   }, [taskData, setSelectedTask])
 
+  const previousLoading = useRef(taskIsLoading)
+
   useEffect(() => {
-    if (taskIsLoading || task === 'create' || taskData) {
+    const hasFinishedLoading = previousLoading.current && !taskIsLoading
+    previousLoading.current = taskIsLoading
+    if (!hasFinishedLoading) return
+
+    if (task === 'create' || taskData) {
       return
     }
 


### PR DESCRIPTION
## Summary
- avoid running not-found logic while new note or task is still loading

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_68826ef80f2c8328a97425622a84e7dc