### PR TITLE
Add customizable currency settings

### DIFF
--- a/app/apis/firestore/user.ts
+++ b/app/apis/firestore/user.ts
@@ -20,6 +20,7 @@ import {
 import { auth, firestore } from '~/lib/configs/firebase'
 import {
   TUpdateAppearanceRequest,
+  TUpdateCurrencyRequest,
   TUpdateProfileRequest,
 } from '~/lib/types/settings'
 import { TSignInRequest, TSignUpRequest, TUserResponse } from '~/lib/types/user'
@@ -110,6 +111,20 @@ export const updateProfile = async (userData: TUpdateProfileRequest) => {
 }
 
 export const updateAppearance = async (data: TUpdateAppearanceRequest) => {
+  if (!firestore) {
+    throw new Error('Firebase Firestore is not initialized.')
+  }
+  if (!auth?.currentUser) {
+    throw new Error('No user is currently signed in.')
+  }
+  const reference = doc(firestore, 'users', auth.currentUser.uid)
+  return await updateDoc(reference, {
+    ...data,
+    updatedAt: new Date(),
+  })
+}
+
+export const updateCurrency = async (data: TUpdateCurrencyRequest) => {
   if (!firestore) {
     throw new Error('Firebase Firestore is not initialized.')
   }

--- a/app/components/base/number-format-selector/constant.ts
+++ b/app/components/base/number-format-selector/constant.ts
@@ -1,0 +1,4 @@
+export const numberFormatOptions = [
+  { value: 'en-US', label: 'en-US' },
+  { value: 'id-ID', label: 'id-ID' },
+]

--- a/app/components/base/number-format-selector/index.tsx
+++ b/app/components/base/number-format-selector/index.tsx
@@ -1,0 +1,103 @@
+import { Slot } from '@radix-ui/react-slot'
+import { Globe } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '~/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
+import { Label } from '~/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group'
+
+import { numberFormatOptions } from './constant'
+import { TParameters, TProperties } from './type'
+
+export const NumberFormatSelector = (properties: TProperties) => {
+  const { type = 'dropdown', onChange, value } = properties
+
+  const changeFormat = (lng: string) => {
+    onChange?.(lng)
+  }
+
+  if (type === 'radio') {
+    return (
+      <Radio
+        value={value}
+        changeFormat={changeFormat}
+      />
+    )
+  }
+
+  return (
+    <Dropdown
+      value={value}
+      changeFormat={changeFormat}
+    />
+  )
+}
+
+const Radio = (parameters: TParameters) => {
+  const { changeFormat, value } = parameters
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-1">
+      <Label>{t('settings.currency.form.locale.selector')}</Label>
+      <Slot>
+        <RadioGroup
+          onValueChange={changeFormat}
+          value={value}
+          className="flex flex-col"
+        >
+          {numberFormatOptions.map((option) => (
+            <div
+              key={option.value}
+              className="flex items-center space-x-3 space-y-0"
+            >
+              <Slot>
+                <RadioGroupItem value={option.value} id={option.value} />
+              </Slot>
+              <Label
+                className="font-normal text-muted-foreground"
+                htmlFor={option.value}
+              >
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </Slot>
+    </div>
+  )
+}
+
+const Dropdown = (parameters: TParameters) => {
+  const { changeFormat, value } = parameters
+  const { t } = useTranslation()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Globe className="h-[1.2rem] w-[1.2rem]" />
+          <span className="sr-only">
+            {t('settings.currency.form.locale.selector')}
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup value={value} onValueChange={changeFormat}>
+          {numberFormatOptions.map((option) => (
+            <DropdownMenuRadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/components/base/number-format-selector/type.ts
+++ b/app/components/base/number-format-selector/type.ts
@@ -1,0 +1,10 @@
+export type TProperties = {
+  type?: 'dropdown' | 'radio'
+  value?: string
+  onChange?: (lng: string) => void
+}
+
+export type TParameters = {
+  value?: string
+  changeFormat: (lng: string) => void
+}

--- a/app/components/pages/general-settings/currency.tsx
+++ b/app/components/pages/general-settings/currency.tsx
@@ -36,12 +36,20 @@ export const Currency = () => {
 
   const formMethods = useForm<TUpdateCurrencyRequest>({
     resolver: zodResolver(currencySettingSchema()),
-    values: {
+    defaultValues: {
       numberFormat: userData?.numberFormat ?? numberFormat,
       currencies: userData?.currencies ?? currencies,
       defaultCurrency: userData?.defaultCurrency ?? defaultCurrency,
     },
   })
+
+  useEffect(() => {
+    formMethods.reset({
+      numberFormat: userData?.numberFormat ?? numberFormat,
+      currencies: userData?.currencies ?? currencies,
+      defaultCurrency: userData?.defaultCurrency ?? defaultCurrency,
+    })
+  }, [userData, numberFormat, currencies, defaultCurrency, formMethods])
 
   const { handleSubmit, watch, control, formState } = formMethods
 
@@ -78,9 +86,7 @@ export const Currency = () => {
     <Card>
       <CardHeader>
         <CardTitle>{t('settings.currency.title')}</CardTitle>
-        <CardDescription>
-          {t('settings.currency.description')}
-        </CardDescription>
+        <CardDescription>{t('settings.currency.description')}</CardDescription>
       </CardHeader>
       <FormProvider {...formMethods}>
         <form onSubmit={onSubmit}>
@@ -98,7 +104,10 @@ export const Currency = () => {
             </div>
             <div className="space-y-2">
               {fields.map((field, index) => (
-                <div key={field.id} className="flex items-end gap-2">
+                <div
+                  key={field.id}
+                  className="flex items-end gap-2"
+                >
                   <Input<TUpdateCurrencyRequest>
                     name={`currencies.${index}.code` as const}
                     label={t('settings.currency.form.currency.code')}

--- a/app/components/pages/general-settings/currency.tsx
+++ b/app/components/pages/general-settings/currency.tsx
@@ -49,7 +49,7 @@ export const Currency = () => {
       currencies: userData?.currencies ?? currencies,
       defaultCurrency: userData?.defaultCurrency ?? defaultCurrency,
     })
-  }, [userData, numberFormat, currencies, defaultCurrency, formMethods])
+  }, [userData]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const { handleSubmit, watch, control, formState } = formMethods
 

--- a/app/components/pages/general-settings/currency.tsx
+++ b/app/components/pages/general-settings/currency.tsx
@@ -1,0 +1,147 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Plus, Trash } from 'lucide-react'
+import { useEffect } from 'react'
+import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '~/components/base/button'
+import { Input } from '~/components/base/input'
+import { NumberFormatSelector } from '~/components/base/number-format-selector'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card'
+import { useCurrency } from '~/lib/contexts/currency'
+import { useUserData } from '~/lib/hooks/use-get-user'
+import { useUpdateCurrency } from '~/lib/hooks/use-update-currency'
+import { TUpdateCurrencyRequest } from '~/lib/types/settings'
+import { currencySettingSchema } from '~/lib/validations/settings'
+
+export const Currency = () => {
+  const { t } = useTranslation()
+  const {
+    numberFormat,
+    currencies,
+    defaultCurrency,
+    setNumberFormat,
+    setCurrencies,
+    setDefaultCurrency,
+  } = useCurrency()
+  const { mutate, isPending } = useUpdateCurrency()
+  const { data: userData } = useUserData()
+
+  const formMethods = useForm<TUpdateCurrencyRequest>({
+    resolver: zodResolver(currencySettingSchema()),
+    values: {
+      numberFormat: userData?.numberFormat ?? numberFormat,
+      currencies: userData?.currencies ?? currencies,
+      defaultCurrency: userData?.defaultCurrency ?? defaultCurrency,
+    },
+  })
+
+  const { handleSubmit, watch, control, formState } = formMethods
+
+  const watchNumberFormat = watch('numberFormat')
+  const watchCurrencies = watch('currencies')
+  const watchDefaultCurrency = watch('defaultCurrency')
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'currencies',
+  })
+
+  useEffect(() => {
+    if (watchNumberFormat) setNumberFormat(watchNumberFormat)
+  }, [watchNumberFormat, setNumberFormat])
+
+  useEffect(() => {
+    setCurrencies(watchCurrencies)
+  }, [watchCurrencies, setCurrencies])
+
+  useEffect(() => {
+    if (watchDefaultCurrency) setDefaultCurrency(watchDefaultCurrency)
+  }, [watchDefaultCurrency, setDefaultCurrency])
+
+  const onSubmit = handleSubmit(async (data) => {
+    await mutate(data)
+  })
+
+  const handleAddCurrency = () => {
+    append({ code: '', digits: 0 })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('settings.currency.title')}</CardTitle>
+        <CardDescription>
+          {t('settings.currency.description')}
+        </CardDescription>
+      </CardHeader>
+      <FormProvider {...formMethods}>
+        <form onSubmit={onSubmit}>
+          <CardContent className="space-y-6">
+            <NumberFormatSelector
+              type="radio"
+              value={watchNumberFormat}
+              onChange={(value) => formMethods.setValue('numberFormat', value)}
+            />
+            <div className="space-y-2">
+              <Input<TUpdateCurrencyRequest>
+                name="defaultCurrency"
+                label={t('settings.currency.form.default.selector')}
+              />
+            </div>
+            <div className="space-y-2">
+              {fields.map((field, index) => (
+                <div key={field.id} className="flex items-end gap-2">
+                  <Input<TUpdateCurrencyRequest>
+                    name={`currencies.${index}.code` as const}
+                    label={t('settings.currency.form.currency.code')}
+                    className="flex-1"
+                  />
+                  <Input<TUpdateCurrencyRequest>
+                    name={`currencies.${index}.digits` as const}
+                    label={t('settings.currency.form.currency.digits')}
+                    type="number"
+                    className="w-20"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={() => remove(index)}
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleAddCurrency}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t('settings.currency.form.add')}
+              </Button>
+            </div>
+          </CardContent>
+          <CardFooter className="border-t px-6 py-4">
+            <Button
+              className="w-fit"
+              isLoading={isPending}
+              disabled={isPending || !formState.isDirty}
+              type="submit"
+            >
+              {t('form.save')}
+            </Button>
+          </CardFooter>
+        </form>
+      </FormProvider>
+    </Card>
+  )
+}

--- a/app/components/pages/general-settings/index.tsx
+++ b/app/components/pages/general-settings/index.tsx
@@ -1,4 +1,5 @@
 import { Appearance } from './appearance'
+import { Currency } from './currency'
 import { Profile } from './profile'
 
 export const GeneralSettingsPage = () => {
@@ -6,6 +7,7 @@ export const GeneralSettingsPage = () => {
     <div className="grid gap-6">
       <Profile />
       <Appearance />
+      <Currency />
     </div>
   )
 }

--- a/app/lib/contexts/currency.tsx
+++ b/app/lib/contexts/currency.tsx
@@ -1,0 +1,98 @@
+import { createContext, useState, useContext, ReactNode } from 'react'
+
+type TCurrency = {
+  code: string
+  digits: number
+}
+
+type CurrencyProviderProperties = {
+  children: ReactNode
+  defaultNumberFormat?: string
+  defaultCurrencies?: TCurrency[]
+  defaultCurrency?: string
+  numberFormatStorageKey?: string
+  currenciesStorageKey?: string
+  defaultCurrencyStorageKey?: string
+}
+
+type CurrencyProviderState = {
+  numberFormat: string
+  currencies: TCurrency[]
+  defaultCurrency: string
+  setNumberFormat: (format: string) => void
+  setCurrencies: (currencies: TCurrency[]) => void
+  setDefaultCurrency: (currency: string) => void
+}
+
+const initialState: CurrencyProviderState = {
+  numberFormat: 'en-US',
+  currencies: [],
+  defaultCurrency: '',
+  setNumberFormat: () => null,
+  setCurrencies: () => null,
+  setDefaultCurrency: () => null,
+}
+
+const CurrencyProviderContext = createContext<CurrencyProviderState>(initialState)
+
+export const CurrencyProvider = ({
+  children,
+  defaultNumberFormat = 'en-US',
+  defaultCurrencies = [],
+  defaultCurrency = '',
+  numberFormatStorageKey = 'number-format',
+  currenciesStorageKey = 'currencies',
+  defaultCurrencyStorageKey = 'default-currency',
+}: CurrencyProviderProperties) => {
+  const [numberFormat, setNumberFormatState] = useState<string>(
+    () => localStorage.getItem(numberFormatStorageKey) || defaultNumberFormat,
+  )
+  const [currencies, setCurrenciesState] = useState<TCurrency[]>(() => {
+    const stored = localStorage.getItem(currenciesStorageKey)
+    return stored ? JSON.parse(stored) : defaultCurrencies
+  })
+  const [currentCurrency, setCurrentCurrencyState] = useState<string>(
+    () =>
+      localStorage.getItem(defaultCurrencyStorageKey) ||
+      defaultCurrency ||
+      defaultCurrencies[0]?.code ||
+      '',
+  )
+
+  const setNumberFormat = (format: string) => {
+    localStorage.setItem(numberFormatStorageKey, format)
+    setNumberFormatState(format)
+  }
+
+  const setCurrencies = (list: TCurrency[]) => {
+    localStorage.setItem(currenciesStorageKey, JSON.stringify(list))
+    setCurrenciesState(list)
+  }
+
+  const setDefaultCurrency = (code: string) => {
+    localStorage.setItem(defaultCurrencyStorageKey, code)
+    setCurrentCurrencyState(code)
+  }
+
+  const value: CurrencyProviderState = {
+    numberFormat,
+    currencies,
+    defaultCurrency: currentCurrency,
+    setNumberFormat,
+    setCurrencies,
+    setDefaultCurrency,
+  }
+
+  return (
+    <CurrencyProviderContext.Provider value={value}>
+      {children}
+    </CurrencyProviderContext.Provider>
+  )
+}
+
+export const useCurrency = () => {
+  const context = useContext(CurrencyProviderContext)
+  if (context === undefined)
+    throw new Error('useCurrency must be used within a CurrencyProvider')
+  return context
+}

--- a/app/lib/hooks/use-update-currency.ts
+++ b/app/lib/hooks/use-update-currency.ts
@@ -1,0 +1,48 @@
+import { FirebaseError } from 'firebase/app'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRevalidator } from 'react-router'
+
+import { updateCurrency } from '~/apis/firestore/user'
+import { authError } from '~/lib/constants/firebase'
+import { TUpdateCurrencyRequest } from '~/lib/types/settings'
+
+import { toast } from './use-toast'
+
+export const useUpdateCurrency = () => {
+  const { revalidate } = useRevalidator()
+  const { t } = useTranslation()
+  const [isPending, setIsPending] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const mutate = async (data: TUpdateCurrencyRequest) => {
+    setIsPending(true)
+    setIsError(false)
+    setIsSuccess(false)
+    try {
+      await updateCurrency(data)
+      toast({
+        description: t('settings.currency.toast.updated'),
+      })
+      setIsSuccess(true)
+      revalidate()
+    } catch (error: unknown) {
+      setIsError(true)
+      let message = String(error)
+      if (error instanceof FirebaseError) {
+        message =
+          authError.find((item) => item.code === error.code)?.message ||
+          error.message
+      }
+      toast({
+        variant: 'destructive',
+        description: message,
+      })
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return { mutate, isPending, isError, isSuccess }
+}

--- a/app/lib/types/settings.ts
+++ b/app/lib/types/settings.ts
@@ -10,3 +10,14 @@ export type TUpdateAppearanceRequest = {
   language: string
   size: Size
 }
+
+export type TCurrency = {
+  code: string
+  digits: number
+}
+
+export type TUpdateCurrencyRequest = {
+  numberFormat: string
+  currencies: TCurrency[]
+  defaultCurrency: string
+}

--- a/app/lib/types/user.ts
+++ b/app/lib/types/user.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { Theme, Size } from '~/lib/contexts/theme'
 import { TTime } from '~/lib/types/common'
+import { TCurrency } from '~/lib/types/settings'
 import { emailSchema, signInSchema, signUpSchema } from '~/lib/validations/user'
 
 export type TSignInRequest = z.infer<ReturnType<typeof signInSchema>>
@@ -22,6 +23,7 @@ export type TUserResponse = {
   createdAt: TTime
   updatedAt: TTime
   defaultCurrency?: string
+  currencies?: TCurrency[]
   numberFormat?: string
   language?: string
   theme?: Theme

--- a/app/lib/validations/settings.ts
+++ b/app/lib/validations/settings.ts
@@ -3,3 +3,15 @@ import { z } from 'zod'
 export const generalSettingSchema = z.object({
   displayName: z.string().min(1, { message: 'Display name is required.' }),
 })
+
+export const currencySettingSchema = () =>
+  z.object({
+    numberFormat: z.string().min(1, { message: 'Required' }),
+    currencies: z.array(
+      z.object({
+        code: z.string().min(1, { message: 'Required' }),
+        digits: z.number().min(0).max(8),
+      }),
+    ),
+    defaultCurrency: z.string().min(1, { message: 'Required' }),
+  })

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -299,6 +299,20 @@
         "updated": "Appearance updated successfully."
       }
     },
+    "currency": {
+      "title": "Currency",
+      "description": "Manage your currencies and formatting.",
+      "form": {
+        "locale": { "selector": "Locale" },
+        "default": { "selector": "Default Currency" },
+        "currency": {
+          "code": "Code",
+          "digits": "Digits"
+        },
+        "add": "Add currency"
+      },
+      "toast": { "updated": "Currency settings updated." }
+    },
     "email": {
       "title": "Change email address",
       "description": "Update your email address.",

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -299,6 +299,20 @@
         "updated": "Pengaturan tampilan berhasil diperbarui."
       }
     },
+    "currency": {
+      "title": "Mata Uang",
+      "description": "Kelola mata uang dan format.",
+      "form": {
+        "locale": { "selector": "Format Angka" },
+        "default": { "selector": "Mata Uang Default" },
+        "currency": {
+          "code": "Kode",
+          "digits": "Digit"
+        },
+        "add": "Tambah mata uang"
+      },
+      "toast": { "updated": "Pengaturan mata uang berhasil diperbarui." }
+    },
     "email": {
       "title": "Perbarui alamat email",
       "description": "Perbarui alamat email Anda.",

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -4,6 +4,7 @@ import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
 
 import { LoadingSpinner } from '~/components/base/loading-spinner'
 import { Rootlayout } from '~/components/layouts/root'
+import { CurrencyProvider } from '~/lib/contexts/currency'
 import { FirebaseProvider } from '~/lib/contexts/firebase'
 import { ThemeProvider, useTheme } from '~/lib/contexts/theme'
 
@@ -17,9 +18,11 @@ const App = () => {
   return (
     <FirebaseProvider>
       <ThemeProvider>
-        <Rootlayout>
-          <Outlet />
-        </Rootlayout>
+        <CurrencyProvider>
+          <Rootlayout>
+            <Outlet />
+          </Rootlayout>
+        </CurrencyProvider>
       </ThemeProvider>
     </FirebaseProvider>
   )

--- a/app/routes/_layout._main.tsx
+++ b/app/routes/_layout._main.tsx
@@ -5,6 +5,7 @@ import { Outlet } from 'react-router'
 import { fetchUserData } from '~/apis/firestore/user'
 import { Navbar } from '~/components/layouts/navbar'
 import { ScrollArea } from '~/components/ui/scroll-area'
+import { useCurrency } from '~/lib/contexts/currency'
 import { useTheme } from '~/lib/contexts/theme'
 import { useUserData } from '~/lib/hooks/use-get-user'
 
@@ -19,6 +20,8 @@ export const clientLoader = async () => {
 const Main = () => {
   const { data: userData } = useUserData()
   const { setTheme, setSize, theme, size } = useTheme()
+  const { setNumberFormat, setCurrencies, setDefaultCurrency, numberFormat } =
+    useCurrency()
   const { i18n } = useTranslation()
 
   useEffect(() => {
@@ -26,7 +29,26 @@ const Main = () => {
     if (userData?.language && i18n.language !== userData.language)
       i18n.changeLanguage(userData.language)
     if (userData?.size && size !== userData.size) setSize(userData.size)
-  }, [userData, setTheme, i18n, theme, setSize, size])
+    if (
+      userData?.numberFormat &&
+      numberFormat !== userData.numberFormat
+    )
+      setNumberFormat(userData.numberFormat)
+    if (userData?.currencies) setCurrencies(userData.currencies)
+    if (userData?.defaultCurrency)
+      setDefaultCurrency(userData.defaultCurrency)
+  }, [
+    userData,
+    setTheme,
+    i18n,
+    theme,
+    setSize,
+    size,
+    setNumberFormat,
+    setCurrencies,
+    setDefaultCurrency,
+    numberFormat,
+  ])
 
   return (
     <ScrollArea className="flex h-dvh w-full">


### PR DESCRIPTION
## Summary
- allow user currency preferences
- support NumberFormat locale selection with defaults
- persist currency data per user

## Testing
- `pnpm validate`

------
https://chatgpt.com/codex/tasks/task_e_688324e8778083289112ea9e8454c6c8