### PR TITLE
Prompt before leaving dirty create form

### DIFF
--- a/app/components/pages/note-detail/form.tsx
+++ b/app/components/pages/note-detail/form.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
 import { Action } from '~/components/base/action'
 import { MilkdownEditor } from '~/components/base/milkdown-editor'
+import { Modal } from '~/components/base/modal'
 import { Textarea } from '~/components/base/textarea'
 import { useNote } from '~/components/pages/notes'
 import { auth } from '~/lib/configs/firebase'
@@ -68,6 +70,16 @@ export const Form = (properties: TFormProperties) => {
   const watchTitle = watch('title')
   const watchContent = watch('content')
 
+  const [openBack, setOpenBack] = useState(false)
+
+  const handleBack = () => {
+    if (!selectedNote && isDirty) {
+      setOpenBack(true)
+      return
+    }
+    handleBackNote()
+  }
+
   const onSubmit = handleSubmit(async (data) => {
     if ((data.title.length === 0 && data.content.length === 0) || !isDirty) {
       return
@@ -107,7 +119,7 @@ export const Form = (properties: TFormProperties) => {
               handleShare={() => handleShareNote({ note })}
               handleUnlink={() => handleUnlinkNote({ note })}
               sharedCount={sharedCount}
-              handleBack={() => handleBackNote()}
+              handleBack={handleBackNote}
             />
           ) : (
             <Action
@@ -115,7 +127,7 @@ export const Form = (properties: TFormProperties) => {
               buttonClassName="supports-[backdrop-filter]:bg-accent/20 backdrop-blur"
               isLoading={isCreatePending}
               isCreate={true}
-              handleBack={() => handleBackNote()}
+              handleBack={handleBack}
               disabled={!isDirty}
             />
           )}
@@ -150,6 +162,21 @@ export const Form = (properties: TFormProperties) => {
               : `(${t('form.permissions.readOnly')})`)}
         </span>
       </span>
+      <Modal
+        open={openBack}
+        setOpen={setOpenBack}
+        handleConfirm={handleBackNote}
+        variant="destructive"
+        title={
+          <Trans
+            i18nKey="form.back"
+            values={{ item: t('notes.title') }}
+            components={{ span: <span className="text-primary" /> }}
+          />
+        }
+      >
+        <></>
+      </Modal>
     </FormProvider>
   )
 }

--- a/app/components/pages/task-detail/form.tsx
+++ b/app/components/pages/task-detail/form.tsx
@@ -2,11 +2,12 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Edit, Trash, ChevronUp, ChevronDown } from 'lucide-react'
 import { useState } from 'react'
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
 import { Action } from '~/components/base/action'
 import { Checkbox } from '~/components/base/checkbox'
+import { Modal } from '~/components/base/modal'
 import { Textarea } from '~/components/base/textarea'
 import { useTask } from '~/components/pages/tasks'
 import { Button } from '~/components/ui/button'
@@ -89,6 +90,16 @@ export const Form = (properties: TFormProperties) => {
   const watchTitle = watch('title')
   const watchItem = watch('item')
   const watchContent = watch('content')
+
+  const [openBack, setOpenBack] = useState(false)
+
+  const handleBack = () => {
+    if (!selectedTask && isDirty) {
+      setOpenBack(true)
+      return
+    }
+    handleBackTask()
+  }
 
   const checkedAll =
     watchContent.length > 0
@@ -291,7 +302,7 @@ export const Form = (properties: TFormProperties) => {
               handleShare={() => handleShareTask({ task })}
               handleUnlink={() => handleUnlinkTask({ task })}
               sharedCount={sharedCount}
-              handleBack={() => handleBackTask()}
+              handleBack={handleBackTask}
               handleToggleCheckAll={handleToggleCheckAll}
               checkedAll={checkedAll}
             />
@@ -301,7 +312,7 @@ export const Form = (properties: TFormProperties) => {
               buttonClassName="supports-[backdrop-filter]:bg-accent/20 backdrop-blur"
               isLoading={isCreatePending}
               isCreate={true}
-              handleBack={() => handleBackTask()}
+              handleBack={handleBack}
               disabled={!isDirty}
               handleToggleCheckAll={handleToggleCheckAll}
               checkedAll={checkedAll}
@@ -477,6 +488,21 @@ export const Form = (properties: TFormProperties) => {
               : `(${t('form.permissions.readOnly')})`)}
         </span>
       </span>
+      <Modal
+        open={openBack}
+        setOpen={setOpenBack}
+        handleConfirm={handleBackTask}
+        variant="destructive"
+        title={
+          <Trans
+            i18nKey="form.back"
+            values={{ item: t('tasks.title') }}
+            components={{ span: <span className="text-primary" /> }}
+          />
+        }
+      >
+        <></>
+      </Modal>
     </FormProvider>
   )
 }

--- a/app/localization/locales/en/common.json
+++ b/app/localization/locales/en/common.json
@@ -30,6 +30,7 @@
     "confirm": "Confirm",
     "undo": "Undo",
     "openPage": "Open Page",
+    "back": "Discard this <span>{{item}}</span>?",
     "permissions": {
       "select": "Choose permissions",
       "readOnly": "Read only",

--- a/app/localization/locales/id/common.json
+++ b/app/localization/locales/id/common.json
@@ -30,6 +30,7 @@
     "confirm": "Iya",
     "undo": "Batal",
     "openPage": "Buka Halaman",
+    "back": "Batalkan <span>{{item}}</span> ini?",
     "permissions": {
       "select": "Pilih izin",
       "readOnly": "Hanya baca",


### PR DESCRIPTION
## Summary
- add `form.back` translation strings
- prompt when navigating back from a dirty create form for notes or tasks
- call `handleBackNote`/`handleBackTask` for existing items

## Testing
- `pnpm validate`


------
https://chatgpt.com/codex/tasks/task_e_688897ccde8c8328b2364222d8dc7903